### PR TITLE
Fix ueberzug backend's y position being off by one

### DIFF
--- a/lua/image/backends/ueberzug.lua
+++ b/lua/image/backends/ueberzug.lua
@@ -75,7 +75,7 @@ backend.render = function(image, x, y, width, height)
     identifier = image.id,
     path = image.cropped_path,
     x = x,
-    y = y,
+    y = y - 1,
     width = width,
     height = height,
   })

--- a/lua/image/backends/ueberzug.lua
+++ b/lua/image/backends/ueberzug.lua
@@ -75,7 +75,7 @@ backend.render = function(image, x, y, width, height)
     identifier = image.id,
     path = image.cropped_path,
     x = x,
-    y = y - 1,
+    y = y,
     width = width,
     height = height,
   })

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -5,8 +5,19 @@ local magick = require("image/magick")
 local get_global_offsets = function()
   local x = 0
   local y = 0
-  if vim.opt.number then x = x + vim.opt.numberwidth:get() end
-  if vim.opt.signcolumn ~= "no" then x = x + 2 end
+
+  local numberwidth = math.max(
+      vim.opt.numberwidth:get(),
+      ('' .. vim.api.nvim_buf_line_count(0)):len()
+        + (vim.opt.relativenumber:get() and 1 or 0))
+
+  if vim.opt.number then x = x + numberwidth end
+
+  local signcolumn = vim.opt.signcolumn:get()
+  if signcolumn ~= "no" then
+      x = x + math.max(0, 2 - (signcolumn == "number" and numberwidth or 0))
+  end
+
   if vim.opt.showtabline == 2 then y = y + 1 end
   if vim.opt.winbar ~= "none" then y = y + 1 end
   return { x = x, y = y }
@@ -106,7 +117,7 @@ local render = function(image)
     -- global offsets
     local global_offsets = get_global_offsets()
     x_offset = global_offsets.x - window.scroll_x
-    y_offset = global_offsets.y + 1 - window.scroll_y
+    y_offset = global_offsets.y - window.scroll_y
 
     -- window offsets
     window_offset_x = window.x


### PR DESCRIPTION
Before:
![image](https://github.com/3rd/image.nvim/assets/24369412/26d76ca4-b20e-4156-8337-31cfb67de83f)
After:
![image](https://github.com/3rd/image.nvim/assets/24369412/7c159374-c369-4eca-8576-8f5839dd0b09)