### PR TITLE
Use percent orig width/height for down scaling

### DIFF
--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -34,7 +34,9 @@ local adjust_to_aspect_ratio = function(term_size, image_width, image_height, wi
   local aspect_ratio = image_width / image_height
   local pixel_width = width * term_size.cell_width
   local pixel_height = height * term_size.cell_height
-  if width > height then
+  local percent_orig_width = pixel_width / image_width
+  local percent_orig_height = pixel_height / image_height
+  if percent_orig_height > percent_orig_width then
     local new_height = math.ceil(pixel_width / aspect_ratio / term_size.cell_height)
     return width, new_height
   else


### PR DESCRIPTION
This change better respects the users configured max width and height values when rendering an image. Addressing #19 

## higher level overview of how

When down-scaling images, we crush the image to the max height and width, and then attempt to restore the aspect ratio. When restoring the aspect ration, we now take the percentage of the original dimension (either width or height) that's smaller, keep that smaller value, and scale the other to match.

This should always be more accurate than what we were previously doing, which was just keeping the larger value and scaling the smaller value to match.