### PR TITLE
fix: Buffer Relative Placement

### DIFF
--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -164,6 +164,12 @@ local render = function(image)
 
   -- utils.debug(("(4) x: %d, y: %d, width: %d, height: %d y_offset: %d absolute_x: %d absolute_y: %d"):format( x, y, width, height, y_offset, absolute_x, absolute_y))
 
+  -- try to get a window if there is a buffer without a window
+  if image.buffer and not image.window then
+    local buf_win = vim.fn.getbufinfo(image.buffer)[1].windows
+    if #buf_win > 0 then image.window = buf_win[1] end
+  end
+
   if image.window and image.buffer then
     local win_info = vim.fn.getwininfo(image.window)[1]
     if not win_info then return false end


### PR DESCRIPTION
## current behavior

We can set `buffer` on an image, the same as `window`. When `window` is set (alone or with
`buffer`), the image is positioned _relative_ to the window. If just `buffer` is set (alone) then the
image is positioned _absolutely_ on the screen.

## after this PR

if `buffer` is set and `window` is not, try to find a window that houses the buffer, set `window`
and continue to render now with both `window` and `buffer` set.

### things to consider
- This is a potentially breaking change if anything is relying on the old behavior.
- Two windows showing the same buffer is still not supported (although I think this is true of the
entire plugin)
- Should we actually set the window on the image? or use something temporary for the single render
cycle?

That last question concern is the big one for me. I'm not sure what makes the most sense here
