### PR TITLE
fix: replace '/' with '-' in base64 encode

### DIFF
--- a/lua/image/utils/base64.lua
+++ b/lua/image/utils/base64.lua
@@ -5,7 +5,7 @@
 local ffi = require("ffi")
 local base64 = {}
 
-local b64 = ffi.new("unsigned const char[65]", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+local b64 = ffi.new("unsigned const char[65]", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-")
 
 function base64.encode(str)
   ---@diagnostic disable-next-line: undefined-global


### PR DESCRIPTION
The result of base64.encode will be used as a path. If it contains '/', there will be an error when resizeing the image, because there is no corresponding directory.

I found this problem with a picture similar to `https://<bucketname>.cos.ap-beijing.myqcloud.com/<somenumber>.png?imageSlim`. The query param `imageSlim` is to download compressed pictures.