### PR TITLE
feat: auto-handle hiding/showing the images on tmux window switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,15 @@ require("image").setup({
   max_height_window_percentage = 50,
   window_overlap_clear_enabled = false, -- toggles images when windows are overlapped
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "" },
-  editor_only_render_when_focused = false, -- hide/show images when the editor looses/gains focus
+  editor_only_render_when_focused = false, -- auto show/hide images when the editor gains/looses focus
+  tmux_show_only_in_active_window = false, -- auto show/hide images in the correct Tmux window (needs visual-activity off)
 })
 ```
 
 ## Tmux
 
 - You must set: `set -gq allow-passthrough on`
-- If you want the images to be automatically hidden/shown when you switch windows, set: `set -g visual-activity off`
+- If you want the images to be automatically hidden/shown when you switch windows (`tmux_show_only_in_active_window = true`), set: `set -g visual-activity off`
 
 ### Try it out with a minimal setup
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ require("image").setup({
 })
 ```
 
+## Tmux
+
+- You must set: `set -gq allow-passthrough on`
+- If you want the images to be automatically hidden/shown when you switch windows, set: `set -g visual-activity off`
+
 ### Try it out with a minimal setup
 
 Download [minimal-setup.lua](./minimal-setup.lua) from the root of this repository and run the demo with:

--- a/lua/image/backends/kitty/helpers.lua
+++ b/lua/image/backends/kitty/helpers.lua
@@ -1,6 +1,9 @@
 local utils = require("image/utils")
 local codes = require("image/backends/kitty/codes")
 
+local stdout = vim.loop.new_tty(1, false)
+if not stdout then error("failed to open stdout") end
+
 -- https://github.com/edluffy/hologram.nvim/blob/main/lua/hologram/terminal.lua#L77
 local get_chunked = function(str)
   local chunks = {}
@@ -16,10 +19,10 @@ end
 ---@param escape? boolean
 local write = function(data, tty, escape)
   if data == "" then return end
-  vim.fn.chansend(vim.v.stderr, data)
 
   local payload = data
   if escape and utils.tmux.is_tmux then payload = utils.tmux.escape(data) end
+
   -- utils.debug("write:", vim.inspect(payload), tty)
 
   if tty then
@@ -28,7 +31,8 @@ local write = function(data, tty, escape)
     handle:write(payload)
     handle:close()
   else
-    vim.fn.chansend(vim.v.stderr, payload)
+    -- vim.fn.chansend(vim.v.stderr, payload)
+    stdout:write(payload)
   end
 end
 

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -216,7 +216,7 @@ api.setup = function(options)
   -- auto-toggle on editor focus change
   if state.options.editor_only_render_when_focused or utils.tmux.is_tmux then
     local images_to_restore_on_focus = {}
-    local initial_tmux_window_id = utils.is_tmux and utils.tmux.get_window_id() or nil
+    local initial_tmux_window_id = utils.tmux.get_window_id()
 
     vim.api.nvim_create_autocmd("FocusLost", {
       group = group,
@@ -231,8 +231,8 @@ api.setup = function(options)
             local images = api.get_images()
             for _, current_image in ipairs(images) do
               if current_image.is_rendered then
-                table.insert(images_to_restore_on_focus, current_image)
                 current_image:clear(true)
+                table.insert(images_to_restore_on_focus, current_image)
               end
             end
           end

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -25,6 +25,7 @@ local default_options = {
   window_overlap_clear_enabled = false,
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "" },
   editor_only_render_when_focused = false,
+  tmux_show_only_in_active_window = false,
 }
 
 ---@type State
@@ -214,7 +215,10 @@ api.setup = function(options)
   })
 
   -- auto-toggle on editor focus change
-  if state.options.editor_only_render_when_focused or utils.tmux.is_tmux then
+  if
+    state.options.editor_only_render_when_focused
+    or (state.options.tmux_show_only_in_active_window and utils.tmux.is_tmux)
+  then
     local images_to_restore_on_focus = {}
     local initial_tmux_window_id = utils.tmux.get_window_id()
 

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -17,7 +17,7 @@ local render = function(image)
   local image_rows = math.floor(image.image_height / term_size.cell_height)
   local image_columns = math.floor(image.image_width / term_size.cell_width)
 
-  -- utils.debug(("renderer.render() %s"):format(image.original_path))
+  -- utils.debug(("renderer.render() %s %d"):format(image.id, image.internal_id))
 
   local original_x = image.geometry.x or 0
   local original_y = image.geometry.y or 0
@@ -111,9 +111,7 @@ local render = function(image)
     bounds.bottom = bounds.bottom + global_offsets.y
     bounds.left = bounds.left + global_offsets.x
     bounds.right = bounds.right
-    if utils.offsets.get_border_shape(window.id).left > 0 then
-      bounds.right = bounds.right + 1
-    end
+    if utils.offsets.get_border_shape(window.id).left > 0 then bounds.right = bounds.right + 1 end
 
     -- global max window width/height percentage
     if type(state.options.max_width_window_percentage) == "number" then
@@ -240,10 +238,10 @@ local render = function(image)
 
   -- clear out of bounds images
   if
-      absolute_y + height <= bounds.top
-      or absolute_y >= bounds.bottom
-      or absolute_x + width <= bounds.left
-      or absolute_x >= bounds.right
+    absolute_y + height <= bounds.top
+    or absolute_y >= bounds.bottom
+    or absolute_x + width <= bounds.left
+    or absolute_x >= bounds.right
   then
     if image.is_rendered then
       -- utils.debug("deleting out of bounds image", { id = image.id, x = absolute_x, y = absolute_y, width = width, height = height, bounds = bounds })
@@ -363,13 +361,13 @@ local render = function(image)
   end
 
   if
-      image.is_rendered
-      and image.rendered_geometry.x == rendered_geometry.x
-      and image.rendered_geometry.y == rendered_geometry.y
-      and image.rendered_geometry.width == rendered_geometry.width
-      and image.rendered_geometry.height == rendered_geometry.height
-      and image.crop_hash == initial_crop_hash
-      and image.resize_hash == initial_resize_hash
+    image.is_rendered
+    and image.rendered_geometry.x == rendered_geometry.x
+    and image.rendered_geometry.y == rendered_geometry.y
+    and image.rendered_geometry.width == rendered_geometry.width
+    and image.rendered_geometry.height == rendered_geometry.height
+    and image.crop_hash == initial_crop_hash
+    and image.resize_hash == initial_resize_hash
   then
     -- utils.debug("skipping render", image.id)
     return true

--- a/lua/image/utils/init.lua
+++ b/lua/image/utils/init.lua
@@ -5,6 +5,7 @@ local window = require("image/utils/window")
 local term = require("image/utils/term")
 local math = require("image/utils/math")
 local offsets = require("image/utils/offsets")
+local tmux = require("image/utils/tmux")
 
 local log = logger.create_logger({
   prefix = "[image.nvim]",
@@ -37,4 +38,5 @@ return {
   term = term,
   math = math,
   offsets = offsets,
+  tmux = tmux,
 }

--- a/lua/image/utils/term.lua
+++ b/lua/image/utils/term.lua
@@ -48,8 +48,19 @@ vim.api.nvim_create_autocmd("VimResized", {
   callback = update_size,
 })
 
+local get_tty = function()
+  local handle = io.popen("tty 2>/dev/null")
+  if not handle then return nil end
+  local result = handle:read("*a")
+  handle:close()
+  result = vim.fn.trim(result)
+  if result == "" then return nil end
+  return result
+end
+
 return {
   get_size = function()
     return cached_size
   end,
+  get_tty = get_tty,
 }

--- a/lua/image/utils/tmux.lua
+++ b/lua/image/utils/tmux.lua
@@ -8,6 +8,7 @@ end
 
 local create_dm_getter = function(name)
   return function()
+    if not is_tmux then return nil end
     local result = vim.fn.system("tmux display-message -p '#{" .. name .. "}'")
     return vim.fn.trim(result)
   end

--- a/lua/image/utils/tmux.lua
+++ b/lua/image/utils/tmux.lua
@@ -1,0 +1,31 @@
+local is_tmux = vim.env.TMUX ~= nil
+
+local has_passthrough = false
+if is_tmux then
+  local ok, result = pcall(vim.fn.system, "tmux show -Apv allow-passthrough")
+  if ok and result == "on\n" then has_passthrough = true end
+end
+
+local create_dm_getter = function(name)
+  return function()
+    local result = vim.fn.system("tmux display-message -p '#{" .. name .. "}'")
+    return vim.fn.trim(result)
+  end
+end
+
+local escape = function(sequence)
+  return "\x1bPtmux;" .. sequence:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
+end
+
+return {
+  is_tmux = is_tmux,
+  has_passthrough = has_passthrough,
+  get_pid = create_dm_getter("pid"),
+  get_socket_path = create_dm_getter("socket_path"),
+  get_window_id = create_dm_getter("window_id"),
+  get_window_name = create_dm_getter("window_name"),
+  get_pane_id = create_dm_getter("pane_id"),
+  get_pane_pid = create_dm_getter("pane_pid"),
+  get_pane_tty = create_dm_getter("pane_tty"),
+  escape = escape,
+}

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -159,3 +159,4 @@
 ---@field display_virtual_placeholder? 0|1
 ---@field display_zindex? number
 ---@field display_delete? "a"|"A"|"i"|"I"|"p"
+---@field tty? string

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -35,6 +35,7 @@
 ---@field window_overlap_clear_enabled? boolean
 ---@field window_overlap_clear_ft_ignore? string[]
 ---@field editor_only_render_when_focused? boolean
+---@field tmux_show_only_in_active_window? boolean
 
 ---@class BackendFeatures
 ---@field crop boolean

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -14,6 +14,7 @@
 ---@field extmarks_namespace any
 ---@field remote_cache { [string]: string }
 ---@field tmp_dir string
+---@field disable_decorator_handling boolean
 
 ---@class DocumentIntegrationOptions
 ---@field enabled? boolean


### PR DESCRIPTION
Introduces hacky mechanism for automatically hiding and showing the rendered images when switching tmux windows.
It's independent of the `editor_only_render_when_focused` option, and always enabled when inside Tmux.

Requires `set -g visual-activity off` to work, not having it makes Tmux go bananas and it doesn't flush or render the sequence until it receives user input, not even after triggering navigation commands programatically.

It works by checking if the active tty is the initial one, and if it's not it hijacks whichever one is active and writes the clear control sequence to it. The clearing auto-show-hide is not triggered if the user is in the same Tmux window they were when they started the editor.

It doesn't work if leaving the window from a different pane than the nvim one, as the focus was already lost when the pane was switched. 

@benlubas @S0mbr3 What do you think? I think it's pretty disgusting, but it kinda works :confused: 

https://github.com/3rd/image.nvim/assets/59587503/ab935f7f-2057-408e-9911-25a1cce4e935


