### PR TITLE
Consistent cropping

### DIFF
--- a/lua/image/backends/kitty/init.lua
+++ b/lua/image/backends/kitty/init.lua
@@ -117,6 +117,7 @@ backend.render = function(image, x, y, width, height)
     local pixel_width = width * term_size.cell_width
     local pixel_height = height * term_size.cell_height
     local pixel_top = 0
+    local pixel_left = 0
 
     -- crop top
     if y < image.bounds.top then
@@ -130,11 +131,20 @@ backend.render = function(image, x, y, width, height)
     if y + height > image.bounds.bottom then pixel_height = (image.bounds.bottom - y + 1) * term_size.cell_height end
 
     -- crop right
-    -- if x + width > image.bounds.right then pixel_width = (image.bounds.right - x) * term_size.cell_width end
+    if x + width > image.bounds.right then pixel_width = (image.bounds.right - x) * term_size.cell_width end
+
+    -- crop left
+    if x < image.bounds.left then
+      local visible_columns = width - (image.bounds.left - x)
+      pixel_width = visible_columns * term_size.cell_width
+      pixel_left = (image.bounds.left - x) * term_size.cell_width
+      x = image.bounds.left
+    end
 
     display_payload.display_width = pixel_width
     display_payload.display_height = pixel_height
     display_payload.display_y = pixel_top
+    display_payload.display_x = pixel_left
   end
 
   helpers.update_sync_start()

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -202,10 +202,11 @@ api.setup = function(options)
     end,
   })
 
-  -- rerender on scroll
-  vim.api.nvim_create_autocmd("WinScrolled", {
+  -- rerender on scroll or resize
+  vim.api.nvim_create_autocmd({"WinScrolled", "WinResized"}, {
     group = group,
     callback = function(au)
+      P(au)
       local images = api.get_images({ window = tonumber(au.file) })
       for _, current_image in ipairs(images) do
         current_image:render()

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -206,7 +206,6 @@ api.setup = function(options)
   vim.api.nvim_create_autocmd({"WinScrolled", "WinResized"}, {
     group = group,
     callback = function(au)
-      P(au)
       local images = api.get_images({ window = tonumber(au.file) })
       for _, current_image in ipairs(images) do
         current_image:render()

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -325,9 +325,8 @@ local render = function(image)
   end
 
   -- crop
+  local crop_hash = ("%d-%d-%d-%d"):format(0, crop_offset_top, pixel_width, cropped_pixel_height)
   if needs_crop and not state.backend.features.crop then
-    local crop_hash = ("%d-%d-%d-%d"):format(0, crop_offset_top, pixel_width, cropped_pixel_height)
-
     if (needs_resize and image.resize_hash ~= resize_hash) or image.crop_hash ~= crop_hash then
       local cached_path = cache.cropped[image.path .. ":" .. crop_hash]
 
@@ -355,6 +354,9 @@ local render = function(image)
         cache.cropped[image.path .. ":" .. crop_hash] = image.cropped_path
       end
     end
+  elseif needs_crop then
+    image.cropped_path = image.resized_path
+    image.crop_hash = crop_hash
   else
     image.cropped_path = image.resized_path
     image.crop_hash = nil
@@ -370,6 +372,7 @@ local render = function(image)
       and image.resize_hash == initial_resize_hash
   then
     -- utils.debug("skipping render", image.id)
+    print("skipping render")
     return true
   end
 

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -103,16 +103,8 @@ local render = function(image)
     window_offset_y = window.y
 
     -- window bounds
-    bounds = {
-      top = window.y + global_offsets.y,
-      right = window.x + window.width - global_offsets.x,
-      bottom = window.y + window.height - global_offsets.y,
-      left = window.x + global_offsets.x,
-    }
-
-    -- w/h can take at most 100% of the window
-    width = math.min(width, window.width - original_x - x_offset)
-    height = math.min(height, window.height - original_y - y_offset)
+    bounds = window.rect
+    bounds.bottom = bounds.bottom - 1
 
     -- global max window width/height percentage
     if type(state.options.max_width_window_percentage) == "number" then

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -106,6 +106,15 @@ local render = function(image)
     bounds = window.rect
     bounds.bottom = bounds.bottom - 1
 
+    -- this is ugly, and if get_global_offsets() is changed this could break
+    bounds.top = bounds.top + global_offsets.y
+    bounds.bottom = bounds.bottom + global_offsets.y
+    bounds.left = bounds.left + global_offsets.x
+    bounds.right = bounds.right
+    if utils.offsets.get_border_shape(window.id).left > 0 then
+      bounds.right = bounds.right + 1
+    end
+
     -- global max window width/height percentage
     if type(state.options.max_width_window_percentage) == "number" then
       width = math.min(width, math.floor(window.width * state.options.max_width_window_percentage / 100))

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -372,7 +372,6 @@ local render = function(image)
       and image.resize_hash == initial_resize_hash
   then
     -- utils.debug("skipping render", image.id)
-    print("skipping render")
     return true
   end
 

--- a/lua/image/utils/offsets.lua
+++ b/lua/image/utils/offsets.lua
@@ -1,4 +1,21 @@
 ---@param window_id number
+---@return { top: number, right: number, bottom: number, left: number }
+local get_border_shape = function(window_id)
+  -- border
+  local border = vim.api.nvim_win_get_config(window_id).border
+  -- a list of 8 or any divisor of 8. if it's less than 8 long, it's repeated
+  -- here we care about the top and the left, so positions 2 and 8
+  local shape = { top = 0, right = 0, bottom = 0, left = 0 }
+  if border ~= nil then
+    if #border[(1 % #border) + 1] > 0 then shape.top = 1 end
+    if #border[(7 % #border) + 1] > 0 then shape.left = 1 end
+    if #border[(5 % #border) + 1] > 0 then shape.bottom = 1 end
+    if #border[(3 % #border) + 1] > 0 then shape.right = 1 end
+  end
+  return shape
+end
+
+---@param window_id number
 ---@return { x: number, y: number }
 local get_global_offsets = function(window_id)
   local x = 0
@@ -20,17 +37,14 @@ local get_global_offsets = function(window_id)
   if wininfo and wininfo[1] then x = x + wininfo[1].textoff end
 
   -- border
-  local border = vim.api.nvim_win_get_config(window_id).border
-  -- a list of 8 or any divisor of 8. if it's less than 8 long, it's repeated
-  -- here we care about the top and the left, so positions 2 and 8
-  if border ~= nil then
-    if #border[(1 % #border) + 1] > 0 then y = y + 1 end
-    if #border[(7 % #border) + 1] > 0 then x = x + 1 end
-  end
+  local border_dim = get_border_shape(window_id)
+  x = x + border_dim.left
+  y = y + border_dim.top
 
   return { x = x, y = y }
 end
 
 return {
   get_global_offsets = get_global_offsets,
+  get_border_shape = get_border_shape,
 }


### PR DESCRIPTION
After this change we'll have consistent cropping behavior that follows these rules:

- If an image is not mounted on a window & buffer it shouldn't be resized/cropped at all, the API user should have full control.
- For images that are attached to a window and buffer it should behave the same and crop images at the window bounds, images should not be resized depending on scroll position.

Something of note, the existing `get_global_offsets` function defines the "bounds" of a window to exclude the sign column. This is helpful for placing image inline with text (you don't often want to cover the sign column). But this does mean it's harder to draw over a sign column of a specific window (which is something another plugin might want to do). This is just another thing that we might consider turning into an option in `v2.0.0`

https://github.com/3rd/image.nvim/assets/56943754/5eacf369-b7d5-4219-ac28-9318e939d5d0

Another note. In order to get this behavior I set my `max_height_window_percentage` to `math.huge`. Otherwise it shrinks the image and you can't see the crop happen on resize.

This finally (I hope) closes #42 

This also fixes the issue where the markdown integration draws images over the status bar, but doesn't prevent an image  from being drawn on the status bar if it's not bound to a window