### PR TITLE
Fix Image Flashing

### DIFF
--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -116,12 +116,13 @@ api.setup = function(options)
       if state.options.window_overlap_clear_enabled then
         vim.schedule(function()
           for _, current_window in ipairs(windows) do
+            local cur_win_images = api.get_images({ window = current_window.id, buffer = bufnr })
             if #current_window.masks > 0 then
-              for _, current_image in ipairs(images) do
+              for _, current_image in ipairs(cur_win_images) do
                 current_image:clear(true)
               end
             else
-              for _, current_image in ipairs(images) do
+              for _, current_image in ipairs(cur_win_images) do
                 if not current_image.is_rendered then current_image:render() end
               end
             end


### PR DESCRIPTION
Fixes #52

A recent change introduced a bug where we were looping over images for wrong window when trying to
determine if they were overlapped by other windows, this resulted in rapid flashing as we attempted
to render and hide the image in an infinite loop.

[Here](https://github.com/3rd/image.nvim/commit/440aee9071697b5ac1ac2e69a61c1187311c2cce#diff-3ae45b29c1f8753c3287a7ef1577efc4a433de48f9afa60b7a631377b70678ddL110) is the line that was removed that I'm adding back
