### PR TITLE
fix: parse markdown buffer with markdown parser and get inlines as children

### DIFF
--- a/lua/image/integrations/markdown.lua
+++ b/lua/image/integrations/markdown.lua
@@ -12,31 +12,38 @@ return document.create_document_integration({
   query_buffer_images = function(buffer)
     local buf = buffer or vim.api.nvim_get_current_buf()
 
-    local parser = vim.treesitter.get_parser(buf, "markdown_inline")
-    local root = parser:parse()[1]:root()
-    local query = vim.treesitter.query.parse("markdown_inline", "(image (link_destination) @url) @image")
+    local lang = vim.treesitter.language.get_lang(vim.bo[buf].filetype) or vim.bo[buf].filetype
+    local parser = vim.treesitter.get_parser(buf, lang)
+    local inline_lang = "markdown_inline"
+    local inlines = parser:children()[inline_lang]
+    local inline_query = vim.treesitter.query.parse(inline_lang, "(image (link_destination) @url) @image")
 
     local images = {}
-    local current_image = nil
+    local function get_inline_images(tree)
+      local root = tree:root()
+      local current_image = nil
 
-    ---@diagnostic disable-next-line: missing-parameter
-    for id, node in query:iter_captures(root, 0) do
-      local key = query.captures[id]
-      local value = vim.treesitter.get_node_text(node, buf)
+      ---@diagnostic disable-next-line: missing-parameter
+      for id, node in inline_query:iter_captures(root, 0) do
+        local key = inline_query.captures[id]
+        local value = vim.treesitter.get_node_text(node, buf)
 
-      -- TODO: fix node:range() taking into account the extmarks for SOME FKING REASON
-      if key == "image" then
-        local start_row, start_col, end_row, end_col = node:range()
-        current_image = {
-          node = node,
-          range = { start_row = start_row, start_col = start_col, end_row = end_row, end_col = end_col },
-        }
-      elseif current_image and key == "url" then
-        current_image.url = value
-        table.insert(images, current_image)
-        current_image = nil
+        -- TODO: fix node:range() taking into account the extmarks for SOME FKING REASON
+        if key == "image" then
+          local start_row, start_col, end_row, end_col = node:range()
+          current_image = {
+            node = node,
+            range = { start_row = start_row, start_col = start_col, end_row = end_row, end_col = end_col },
+          }
+        elseif current_image and key == "url" then
+          current_image.url = value
+          table.insert(images, current_image)
+          current_image = nil
+        end
       end
     end
+
+    inlines:for_each_tree(get_inline_images)
 
     return images
   end,

--- a/lua/image/integrations/markdown.lua
+++ b/lua/image/integrations/markdown.lua
@@ -14,6 +14,7 @@ return document.create_document_integration({
 
     local lang = vim.treesitter.language.get_lang(vim.bo[buf].filetype) or vim.bo[buf].filetype
     local parser = vim.treesitter.get_parser(buf, lang)
+    parser:parse(true)
     local inline_lang = "markdown_inline"
     local inlines = parser:children()[inline_lang]
     local inline_query = vim.treesitter.query.parse(inline_lang, "(image (link_destination) @url) @image")


### PR DESCRIPTION
This fixes interactions with other plugins by not accidentally attaching a wrong parser to markdown buffers (that would get re-used by other plugins when they require the parser).

It should also safeguard against future bugs, because previously we would attach the "markdown_inline" parser directly to the buffer, which would also try to parse all the parts that are not plain markdown (like yaml headers, html and code chunks) as inline markdown.

This does change the behavior slightly, but I'd say makes it more expected. Previously, because the whole buffer would be treated as if it where only "markdown_inline", it would also detect images with the markdown syntax in parts that are not markdown, so this is no longer happening. e.g. if you had a code chunk with a comment that contained some markdown image syntax.

````markdown
# Hello world

```{python}
# this is a comment with ![](./some/image.png)
# this will, rightfully, not be rendered anymore
print('hello world')
```

But this will: ![](./some/image.png)

````