### PR TITLE
Use direct mode in kitty when SSH is detected

### DIFF
--- a/lua/image/backends/kitty/helpers.lua
+++ b/lua/image/backends/kitty/helpers.lua
@@ -22,9 +22,7 @@ local write = function(data, tty, escape)
 
   local payload = data
   if escape and utils.tmux.is_tmux then payload = utils.tmux.escape(data) end
-
   -- utils.debug("write:", vim.inspect(payload), tty)
-
   if tty then
     local handle = io.open(tty, "w")
     if not handle then error("failed to open tty") end
@@ -37,6 +35,12 @@ local write = function(data, tty, escape)
 end
 
 local move_cursor = function(x, y, save)
+  if utils.tmux.is_tmux then
+    -- When tmux is running over ssh, set-cursor sometimes doesn't actually get sent
+    -- I don't know why this fixes the issue...
+    local cx = utils.tmux.get_cursor_x()
+    local cy = utils.tmux.get_cursor_y()
+  end
   if save then write("\x1b[s") end
   write("\x1b[" .. y .. ";" .. x .. "H")
   vim.loop.sleep(1)

--- a/lua/image/backends/kitty/helpers.lua
+++ b/lua/image/backends/kitty/helpers.lua
@@ -71,8 +71,14 @@ local write_graphics = function(config, data)
   control_payload = control_payload:sub(0, -2)
 
   if data then
-    if config.transmit_medium ~= codes.control.transmit_medium.direct then data = utils.base64.encode(data) end
+    if config.transmit_medium == codes.control.transmit_medium.direct then
+      local file = io.open(data,"rb")
+      data = file:read("*all")
+    end
+    data = utils.base64.encode(data):gsub("%-","/")
     local chunks = get_chunked(data)
+    local m = #chunks > 1 and 1 or 0
+    control_payload = control_payload .. ",m=" .. m
     for i = 1, #chunks do
       write("\x1b_G" .. control_payload .. ";" .. chunks[i] .. "\x1b\\", config.tty, true)
       if i == #chunks - 1 then

--- a/lua/image/backends/kitty/init.lua
+++ b/lua/image/backends/kitty/init.lua
@@ -34,6 +34,12 @@ end
 
 backend.render = function(image, x, y, width, height)
   local with_virtual_placeholders = backend.state.options.kitty_method == "unicode-placeholders"
+  local is_SSH = (vim.env.SSH_CLIENT ~= nil) or (vim.env.SSH_TTY ~= nil)
+  if is_SSH then
+    current_medium = codes.control.transmit_medium.direct
+  else
+    current_medium = codes.control.transmit_medium.file
+  end
 
   -- transmit image
   local transmit = function()
@@ -41,7 +47,7 @@ backend.render = function(image, x, y, width, height)
       action = codes.control.action.transmit,
       image_id = image.internal_id,
       transmit_format = codes.control.transmit_format.png,
-      transmit_medium = codes.control.transmit_medium.file,
+      transmit_medium = current_medium,
       display_cursor_policy = codes.control.display_cursor_policy.do_not_move,
       display_virtual_placeholder = with_virtual_placeholders and 1 or 0,
       quiet = 2,

--- a/lua/image/utils/tmux.lua
+++ b/lua/image/utils/tmux.lua
@@ -28,5 +28,7 @@ return {
   get_pane_id = create_dm_getter("pane_id"),
   get_pane_pid = create_dm_getter("pane_pid"),
   get_pane_tty = create_dm_getter("pane_tty"),
+  get_cursor_x = create_dm_getter("cursor_x"),
+  get_cursor_y = create_dm_getter("cursor_y"),
   escape = escape,
 }


### PR DESCRIPTION
SSH is determined by checking the environment for SSH_CLIENT and SSH_TTY.

Currently, all calls to the kitty backend "write_graphics" which include data to be transmitted, only supply file-paths as data. Thus we can achieve direct mode by reading from said file.

Direct mode relies on being able to write "/" character instead of "-" once encoded, so this is achieved by a final substitution with gsub. I decided not to change any of the path-creation functions.