### PR TITLE
feat: add svg to render list

### DIFF
--- a/lua/image/utils/magic.lua
+++ b/lua/image/utils/magic.lua
@@ -11,6 +11,8 @@ local sigs = {
   "\x66\x74\x79\x70", -- HEIC
   "\x2F\x2A\x20\x58\x50\x4D\x20\x2A\x2F", -- XPM
   "\x00\x00\x01\x00", -- ICO
+  "<svg", -- SVG
+  "<?xml", -- alternative SVG
 }
 
 ---@param path string


### PR DESCRIPTION
Adds two SVG headers to the acceptable image file headers so this plugin can render SVG files
