### PR TITLE
fix: position with nearby virtual text

### DIFF
--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -26,6 +26,15 @@ local createImage = function(template, global_state)
   return instance
 end
 
+---get the extmark id for the virtual padding for this image
+---@return number?
+function Image:get_extmark_id()
+  local extmark = buf_extmark_map[self.buffer .. ":" .. self.geometry.y]
+  if extmark then
+    return extmark.id
+  end
+end
+
 ---@param geometry? ImageGeometry
 function Image:render(geometry)
   if geometry then self.geometry = vim.tbl_deep_extend("force", self.geometry, geometry) end

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -209,7 +209,9 @@ local render = function(image)
 
           local offset = topfill
           for _, mark in ipairs(extmarks) do
-            if mark.row + 1 ~= original_y then offset = offset + mark.height end
+            if mark.row ~= original_y and mark.id ~= image:get_extmark_id() then
+              offset = offset + mark.height
+            end
           end
 
           absolute_y = absolute_y + offset


### PR DESCRIPTION
When placing images in a buffer right below other virtual text, the image didn't find the virtual text and would therefor overlap it.

it didn't check for virt text in the same position as itself probably as a way to avoid finding it's own virtual padding. I've added a method to get the extmark id for an image, and updated the logic to just exclude it's own extmark.

Before (overlapping existing virtual text):
![image](https://github.com/3rd/image.nvim/assets/56943754/30c9c1ed-3608-4499-9694-430c66f2cfaa)

After:
![image](https://github.com/3rd/image.nvim/assets/56943754/8dfd5a9e-03c7-494f-9692-2d56e9ef6509)
