### PR TITLE
fix: images rendering below extmarks on same line

### DIFF
--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -234,7 +234,10 @@ local render = function(image)
 
           local extmark_offset = topfill
           for _, mark in ipairs(extmarks) do
-            if mark.row ~= original_y and mark.id ~= image:get_extmark_id() then
+            -- Break if we've reached the image's extmark, don't adjust for extmarks on the same
+            -- physical line but below the image's extmark
+            if mark.id == image:get_extmark_id() then break end
+            if mark.row ~= original_y then
               -- check the mark is inside a fold, and skip adding the offset if it is
               for fold_start, fold_end in pairs(folded_ranges) do
                 if mark.row >= fold_start and mark.row < fold_end then


### PR DESCRIPTION
fixes: #84

Currently: 
The virtual text is added after the image, so nvim renders the image padding first, and then the text. But we're assuming that the image should be below all of the extmarks that are on the same line. This is something that I missed in my last PR
<img width="758" alt="image" src="https://github.com/3rd/image.nvim/assets/56943754/4c3770e8-b9ca-45c2-8050-71f8d3ec4303">

After this PR:
Image renders with it's extmark b/c we break out of a loop when we find the images own extmark
<img width="758" alt="image" src="https://github.com/3rd/image.nvim/assets/56943754/bb182e37-b318-46c3-a1c5-4c06177d0925">

