### PR TITLE
feat: configurable resolve_image_path function

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,26 @@ All the backends support rendering inside Tmux.
 - `markdown` - uses [tree-sitter-markdown](https://github.com/MDeiml/tree-sitter-markdown) and supports any Markdown-based grammars (Quarto, VimWiki Markdown)
 - `neorg` - uses [tree-sitter-norg](https://github.com/nvim-neorg/tree-sitter-norg) (also check https://github.com/nvim-neorg/neorg/issues/971)
 
+You can configure where images are searched for on a per-integration basis by passing a function to
+`resolve_image_path` as shown below:
+
+```lua
+require('image').setup({
+  integrations = {
+    markdown = {
+      resolve_image_path = function(document_path, image_path, fallback)
+        -- document_path is the path to the file that contains the image
+        -- image_path is the potentially relative path to the image. for
+        -- markdown it's `![](this text)`
+
+        -- you can call the fallback function to get the default behavior
+        return fallback(document_path, image_path)
+      end,
+    }
+  }
+})
+```
+
 ## API
 
 Check [types.lua](./lua/types.lua) for a better overview of how everything is modeled.

--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -99,7 +99,12 @@ local create_document_integration = function(config)
             end)
           end
         else
-          local path = resolve_absolute_path(item.file_path, item.match.url)
+          local path
+          if ctx.options.resolve_image_path then
+            path = ctx.options.resolve_image_path(item.file_path, item.match.url, resolve_absolute_path)
+          else
+            path = resolve_absolute_path(item.file_path, item.match.url)
+          end
           local ok, image = pcall(ctx.api.from_file, path, {
             id = item.id,
             window = item.window.id,

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -24,6 +24,7 @@
 ---@field clear_in_insert_mode? boolean
 ---@field only_render_image_at_cursor? boolean
 ---@field filetypes? string[]
+---@field resolve_image_path? function
 
 ---@alias IntegrationOptions DocumentIntegrationOptions
 


### PR DESCRIPTION
closes #117 along side #118

This is the other half of what is required to get Obsidian images to work.

Adds a new configuration option for document integrations, `resolve_image_path` which allows the user to pass a function that will be used instead of the `resolve_absolute_path` function that is otherwise used to find images.
