### PR TITLE
dont render if the user is in command-line-window

### DIFF
--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -44,6 +44,10 @@ end
 function Image:render(geometry)
   if geometry then self.geometry = vim.tbl_deep_extend("force", self.geometry, geometry) end
 
+  -- don't render if we are in the conmmand-line-window, in this case previously rendered images can
+  -- be left in place
+  if vim.fn.getcmdwintype()~='' then return end
+
   -- utils.debug(("---------------- %s ----------------"):format(self.id))
   local was_rendered = renderer.render(self)
 

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -84,8 +84,6 @@ local render = function(image)
     -- if the image is tied to a buffer the window must be displaying that buffer
     if image.buffer ~= nil and window.buffer ~= image.buffer then return false end
 
-    -- don't render if we are in the conmmand-line-window
-    if vim.fn.getcmdwintype()~='' then return false end
     -- get topfill and check fold status
     local current_win = vim.api.nvim_get_current_win()
     vim.api.nvim_command("noautocmd call nvim_set_current_win(" .. image.window .. ")")

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -84,6 +84,8 @@ local render = function(image)
     -- if the image is tied to a buffer the window must be displaying that buffer
     if image.buffer ~= nil and window.buffer ~= image.buffer then return false end
 
+    -- don't render if we are in the conmmand-line-window
+    if vim.fn.getcmdwintype()~='' then return false end
     -- get topfill and check fold status
     local current_win = vim.api.nvim_get_current_win()
     vim.api.nvim_command("noautocmd call nvim_set_current_win(" .. image.window .. ")")


### PR DESCRIPTION
This prevents spamming the user with errors due to actions not allowed in command-line-window.
It closes #128.

Now when the user opens the `command-line-window` image.nvim will stop rendering until the user closes the window which should not be a problem for usability.
![image](https://github.com/3rd/image.nvim/assets/31407988/56e19300-9560-477b-970f-0ed72094ea6a)