### PR TITLE
Inline Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,12 @@ local image = api.from_file("/path/to/image.png", {
   id = "my_image_id", -- optional, defaults to a random string
   window = 1000, -- optional, binds image to a window and its bounds
   buffer = 1000, -- optional, binds image to a buffer (paired with window binding)
-  with_virtual_padding = true, -- optional, pads vertically with extmarks
+  with_virtual_padding = true, -- optional, pads vertically with extmarks, defaults to false
+
+  -- optional, binds image to an extmark which it follows. Set to true when
+  -- `with_virtual_padding` is true. defaults to false.
+  inline = true,
+
   ...geometry, -- optional, { x, y, width, height }
 })
 
@@ -192,6 +197,11 @@ local image = api.from_file("https://gist.ro/s/remote.png", {
   window = 1000, -- optional, binds image to a window and its bounds
   buffer = 1000, -- optional, binds image to a buffer (paired with window binding)
   with_virtual_padding = true, -- optional, pads vertically with extmarks
+
+  -- optional, binds image to an extmark which it follows. Set to true when
+  -- `with_virtual_padding` is true. defaults to false.
+  inline = true,
+
   ...geometry, -- optional, { x, y, width, height }
 })
 

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -1,5 +1,3 @@
-local image = require("image/image")
-local magick = require("image/magick")
 local utils = require("image/utils")
 
 ---@type Options
@@ -51,14 +49,17 @@ api.setup = function(options)
   local opts = vim.tbl_deep_extend("force", default_options, options or {})
   state.options = opts
 
-  -- check that magick is available
-  if not magick.has_magick then
-    vim.api.nvim_err_writeln(
-      "image.nvim: magick rock not found, please install it and restart your editor. Error: "
-        .. vim.inspect(magick.magick)
-    )
-    return
-  end
+  vim.schedule(function()
+    local magick = require("image/magick")
+    -- check that magick is available
+    if not magick.has_magick then
+      vim.api.nvim_err_writeln(
+        "image.nvim: magick rock not found, please install it and restart your editor. Error: "
+          .. vim.inspect(magick.magick)
+      )
+      return
+    end
+  end)
 
   -- load backend
   local backend = require("image/backends/" .. opts.backend)
@@ -372,6 +373,7 @@ end
 ---@param options? ImageOptions
 api.from_file = function(path, options)
   guard_setup()
+  local image = require("image/image")
   return image.from_file(path, options, state)
 end
 
@@ -380,6 +382,7 @@ end
 ---@param callback fun(image: Image|nil)
 api.from_url = function(url, options, callback)
   guard_setup()
+  local image = require("image/image")
   image.from_url(url, options, callback, state)
 end
 

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -189,8 +189,8 @@ local render = function(image)
     -- utils.debug(("fold offset: %d"):format(offset))
     absolute_y = absolute_y - offset
 
-    -- extmark offsets
-    if image.with_virtual_padding then
+    -- account for things that push line numbers around
+    if image.inline then
       -- bail if the image is above the top of the window at least by one line
       if topfill == 0 and original_y < topline then
         -- utils.debug("prevent rendering 2", image.id)

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -63,6 +63,7 @@
 ---@field window? number
 ---@field buffer? number
 ---@field with_virtual_padding? boolean
+---@field inline? boolean
 ---@field namespace? string
 
 ---@class ImageBounds
@@ -99,6 +100,7 @@
 ---@field window? number
 ---@field buffer? number
 ---@field with_virtual_padding? boolean
+---@field inline? boolean
 ---@field geometry ImageGeometry
 ---@field rendered_geometry ImageGeometry
 ---@field bounds ImageBounds


### PR DESCRIPTION
# Inline Images

This PR introduces the concept of an `inline` image, and does so without breaking existing functionality. `inline` images are images that display "inline" with other text, they get an extmark to track their location, and they stick to that extmark.

images that have `with_virtual_padding` must be `inline`. (this is also the rule that prevents this PR from breaking existing functionality).

## Motivation

I'm doing this to improve the inline latex rendering of neorg. In conjunction with the `inline` extmark option introduced in nvim v0.10+, this PR allows for images to easily render over concealed text and stick with the text without users of the api having to do all the work that image nvim already does for images `with_virtual_padding`.

I'm sure there are other similar applications too.

## testing

I've daily'ed this for a few days and haven't broken it, I haven't done rigorous testing yet though.

---

Thoughts?
