### PR TITLE
add integrations for html and css files

### DIFF
--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -14,6 +14,12 @@ local default_options = {
     syslang = {
       enabled = true,
     },
+    html = {
+      enabled = true,
+    },
+    css = {
+      enabled = true,
+    },
   },
   max_width = nil,
   max_height = nil,

--- a/lua/image/integrations/css.lua
+++ b/lua/image/integrations/css.lua
@@ -1,0 +1,77 @@
+local document = require("image/utils/document")
+return document.create_document_integration({
+  name = "css",
+  debug = true,
+  default_options = {
+    clear_in_insert_mode = false,
+    download_remote_images = true,
+    only_render_image_at_cursor = false,
+    filetypes = { "css", "sass", "scss" },
+  },
+  query_buffer_images = function(buffer)
+    local buf = buffer or vim.api.nvim_get_current_buf()
+
+    local parser = vim.treesitter.get_parser(buf, "css")
+    local root = parser:parse()[1]:root()
+    local query = vim.treesitter.query.parse(
+      "css",
+      '(call_expression (function_name) @name (#eq? @name "url"))'
+    )
+
+    local images = {}
+
+    ---@diagnostic disable-next-line: missing-parameter
+    for id, node in query:iter_captures(root, 0) do
+      local capture = query.captures[id]
+
+      if capture == "name" then
+        ---@diagnostic disable-next-line: unused-local
+        local start_row, start_col, end_row, end_col = node:range()
+        local line = vim.api.nvim_buf_get_lines(
+          buf,
+          end_row,
+          end_row + 1,
+          false
+        )[1]
+
+        local path = line:sub(start_col):gsub(".*url%([\"'](.-)[\"']%).*$", "%1")
+        print (path)
+
+        if path:sub(1,1) ~= "/" then
+          table.insert(images, {
+            node = node,
+            range = {
+              start_row = start_row,
+              start_col = start_col,
+              end_row = end_row,
+              end_col = end_col,
+            },
+            url = path,
+          })
+        else
+          -- remove leading /
+          path = path:sub(2)
+          -- find closest match upwards 
+          local file = vim.fs.find(path, {
+            upward = true,
+            path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
+          })[1]
+          if file ~= nil then
+            table.insert(images, {
+              node = node,
+              range = {
+                start_row = start_row,
+                start_col = start_col,
+                end_row = end_row,
+                end_col = end_col,
+              },
+              url = file,
+            })
+          end
+        end
+      end
+    end
+
+    return images
+  end
+})

--- a/lua/image/integrations/css.lua
+++ b/lua/image/integrations/css.lua
@@ -36,7 +36,15 @@ return document.create_document_integration({
 
         local path = line:sub(start_col):gsub(".*url%([\"'](.-)[\"']%).*$", "%1")
 
-        if path:sub(1,1) ~= "/" then
+        -- search for path relative to webroot
+        if path:sub(1,1) == "/" then
+          path = vim.fs.find(path:sub(2), {
+            upward = true,
+            path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
+          })[1]
+        end
+
+        if path ~= nil then
           table.insert(images, {
             node = node,
             range = {
@@ -47,26 +55,6 @@ return document.create_document_integration({
             },
             url = path,
           })
-        else
-          -- remove leading /
-          path = path:sub(2)
-          -- find closest match upwards 
-          local file = vim.fs.find(path, {
-            upward = true,
-            path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
-          })[1]
-          if file ~= nil then
-            table.insert(images, {
-              node = node,
-              range = {
-                start_row = start_row,
-                start_col = start_col,
-                end_row = end_row,
-                end_col = end_col,
-              },
-              url = file,
-            })
-          end
         end
       end
     end

--- a/lua/image/integrations/css.lua
+++ b/lua/image/integrations/css.lua
@@ -1,7 +1,7 @@
 local document = require("image/utils/document")
 return document.create_document_integration({
   name = "css",
-  debug = true,
+  -- debug = true,
   default_options = {
     clear_in_insert_mode = false,
     download_remote_images = true,
@@ -35,7 +35,6 @@ return document.create_document_integration({
         )[1]
 
         local path = line:sub(start_col):gsub(".*url%([\"'](.-)[\"']%).*$", "%1")
-        print (path)
 
         if path:sub(1,1) ~= "/" then
           table.insert(images, {

--- a/lua/image/integrations/html.lua
+++ b/lua/image/integrations/html.lua
@@ -37,7 +37,15 @@ return document.create_document_integration({
 
         local path = line:sub(start_col):gsub(".*src=[\"'](.-)[\"'].*$", "%1")
 
-        if path:sub(1,1) ~= "/" then
+        -- search for path relative to webroot
+        if path:sub(1,1) == "/" then
+          path = vim.fs.find(path:sub(2), {
+            upward = true,
+            path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
+          })[1]
+        end
+
+        if path ~= nil then
           table.insert(images, {
             node = node,
             range = {
@@ -48,24 +56,6 @@ return document.create_document_integration({
             },
             url = path,
           })
-        else
-          path = path:sub(2)
-          local file = vim.fs.find(path, {
-            upward = true,
-            path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
-          })[1]
-          if file ~= nil then
-            table.insert(images, {
-              node = node,
-              range = {
-                start_row = start_row,
-                start_col = start_col,
-                end_row = end_row,
-                end_col = end_col,
-              },
-              url = file,
-            })
-          end
         end
       end
     end

--- a/lua/image/integrations/html.lua
+++ b/lua/image/integrations/html.lua
@@ -1,0 +1,75 @@
+local document = require("image/utils/document")
+return document.create_document_integration({
+  name = "html",
+  debug = true,
+  default_options = {
+    clear_in_insert_mode = false,
+    download_remote_images = true,
+    only_render_image_at_cursor = false,
+    filetypes = { "html", "xhtml", "htm" },
+  },
+  query_buffer_images = function(buffer)
+    local buf = buffer or vim.api.nvim_get_current_buf()
+
+    local parser = vim.treesitter.get_parser(buf, "html")
+    local root = parser:parse()[1]:root()
+    local query = vim.treesitter.query.parse(
+      "html",
+      '(attribute (attribute_name) @name (#eq? @name "src")'
+      .. ' (quoted_attribute_value))'
+    )
+
+    local images = {}
+
+    ---@diagnostic disable-next-line: missing-parameter
+    for id, node in query:iter_captures(root, 0) do
+      local capture = query.captures[id]
+
+      if capture == "name" then
+        ---@diagnostic disable-next-line: unused-local
+        local start_row, start_col, end_row, end_col = node:range()
+        local line = vim.api.nvim_buf_get_lines(
+          buf,
+          end_row,
+          end_row + 1,
+          false
+        )[1]
+
+        local path = line:sub(start_col):gsub(".*src=[\"'](.-)[\"'].*$", "%1")
+
+        if path:sub(1,1) ~= "/" then
+          table.insert(images, {
+            node = node,
+            range = {
+              start_row = start_row,
+              start_col = start_col,
+              end_row = end_row,
+              end_col = end_col,
+            },
+            url = path,
+          })
+        else
+          path = path:sub(2)
+          local file = vim.fs.find(path, {
+            upward = true,
+            path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
+          })[1]
+          if file ~= nil then
+            table.insert(images, {
+              node = node,
+              range = {
+                start_row = start_row,
+                start_col = start_col,
+                end_row = end_row,
+                end_col = end_col,
+              },
+              url = file,
+            })
+          end
+        end
+      end
+    end
+
+    return images
+  end
+})

--- a/lua/image/integrations/html.lua
+++ b/lua/image/integrations/html.lua
@@ -1,7 +1,7 @@
 local document = require("image/utils/document")
 return document.create_document_integration({
   name = "html",
-  debug = true,
+  -- debug = true,
   default_options = {
     clear_in_insert_mode = false,
     download_remote_images = true,


### PR DESCRIPTION
I added integrations for html (aswell as xhtml and htm) and css (aswell as sass and scss).

I included code to search for the linked images in parent directories, so image urls relative to the webroot can be resolved. That worked for me as long as webpack did not change the names of packed asset directories.

BTW: in integrations/neorg.lua line 33
```
(#eq? name "image")
```
should actually be
```
(#eq? @name "image"))
```
according to treesitter doku. 

I do not use or have neorg, so maybe you want to check if that is a mistake