### PR TITLE
gate image change updates behind option, and limit updates to just image under cursor

### DIFF
--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -170,7 +170,7 @@ function Image:brightness(brightness)
 
   self.path = altered_path
   self.cropped_path = altered_path
-  self.resize_hash = nil
+  self.date_hash = nil
   self.cropped_hash = nil
   self.resize_hash = nil
   if self.is_rendered then
@@ -190,7 +190,7 @@ function Image:saturation(saturation)
 
   self.path = altered_path
   self.cropped_path = altered_path
-  self.resize_hash = nil
+  self.date_hash = nil
   self.cropped_hash = nil
   self.resize_hash = nil
   if self.is_rendered then
@@ -210,7 +210,7 @@ function Image:hue(hue)
 
   self.path = altered_path
   self.cropped_path = altered_path
-  self.resize_hash = nil
+  self.date_hash = nil
   self.cropped_hash = nil
   self.resize_hash = nil
   if self.is_rendered then
@@ -268,6 +268,7 @@ local from_file = function(path, options, state)
         with_virtual_padding = opts.with_virtual_padding or false,
         inline = opts.inline or opts.with_virtual_padding or false,
         is_rendered = false,
+        date_hash = nil,
         crop_hash = nil,
         resize_hash = nil,
         namespace = opts.namespace or nil,

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -23,6 +23,7 @@ local default_options = {
   window_overlap_clear_enabled = false,
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "" },
   editor_only_render_when_focused = false,
+  check_image_changes_at_cursor = false,
   tmux_show_only_in_active_window = false,
   hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp" },
 }

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -6,8 +6,8 @@ local utils = require("image/utils")
 -- This is where we keep track of the hashes of the resized and cropped versions of the images so we
 -- can avoid processing and writing the same cropped/resized image variant multiple times.
 local cache = {
-  resized = {}, -- { [`${original_path}:${resize_hash}`]: string }
-  cropped = {}, -- { [`${original_path}:${crop_hash}`]: string }
+  resized = {}, -- { [`${original_path}:${modification_date}:${resize_hash}`]: string }
+  cropped = {}, -- { [`${original_path}:${modification_date}:${crop_hash}`]: string }
 }
 
 ---@param image Image
@@ -285,6 +285,7 @@ local render = function(image)
   local cropped_pixel_height = height * term_size.cell_height
   local needs_crop = false
   local needs_resize = false
+  local initial_date_hash = image.date_hash
   local initial_crop_hash = image.crop_hash
   local initial_resize_hash = image.resize_hash
 
@@ -310,10 +311,29 @@ local render = function(image)
 
   -- TODO make this non-blocking
 
+  -- modification_date
+  if state.options.check_image_changes_at_cursor then
+    local cursor_row = vim.api.nvim_win_get_cursor(0)[1]
+    if image.geometry.y == cursor_row or initial_date_hash == nil then
+      local magick_image = magick.load_image(image.path)
+      image.date_hash = magick_image:get_property("date:modify"):gsub("[-:+]", "")
+      magick_image:destroy()
+      if image.date_hash ~= initial_date_hash then
+        image:clear()
+        needs_resize = true
+        needs_crop = true
+      end
+    else
+      image.date_hash = initial_date_hash
+    end
+  else
+    image.date_hash = require("os").date("%Y%m%d%H%M")
+  end
+
   -- resize
   if needs_resize then
-    if image.resize_hash ~= resize_hash then
-      local cached_path = cache.resized[image.path .. ":" .. resize_hash]
+    if image.resize_hash ~= resize_hash or image.date_hash ~= initial_date_hash then
+      local cached_path = cache.resized[image.path .. ":" .. image.date_hash .. ":" .. resize_hash]
 
       -- try cache
       if cached_path then
@@ -329,14 +349,21 @@ local render = function(image)
           resized_image:set_format("png")
           resized_image:scale(pixel_width, pixel_height)
 
-          local tmp_path = state.tmp_dir .. "/" .. utils.base64.encode(image.id) .. "-resized-" .. resize_hash .. ".png"
+          local tmp_path = state.tmp_dir
+            .. "/"
+            .. utils.base64.encode(image.id)
+            .. "-"
+            .. image.date_hash
+            .. "-resized-"
+            .. resize_hash
+            .. ".png"
           resized_image:write(tmp_path)
           resized_image:destroy()
 
           image.resized_path = tmp_path
           image.resize_hash = resize_hash
 
-          cache.resized[image.path .. ":" .. resize_hash] = tmp_path
+          cache.resized[image.path .. ":" .. image.date_hash .. ":" .. resize_hash] = tmp_path
         end
       end
     end
@@ -348,8 +375,12 @@ local render = function(image)
   -- crop
   local crop_hash = ("%d-%d-%d-%d"):format(0, crop_offset_top, pixel_width, cropped_pixel_height)
   if needs_crop and not state.backend.features.crop then
-    if (needs_resize and image.resize_hash ~= resize_hash) or image.crop_hash ~= crop_hash then
-      local cached_path = cache.cropped[image.path .. ":" .. crop_hash]
+    if
+      (needs_resize and image.resize_hash ~= resize_hash)
+      or image.crop_hash ~= crop_hash
+      or image.date_hash ~= initial_date_hash
+    then
+      local cached_path = cache.cropped[image.path .. ":" .. image.date_hash .. ":" .. crop_hash]
 
       -- try cache;
       if cached_path then
@@ -364,7 +395,14 @@ local render = function(image)
         cropped_image:set_format("png")
         cropped_image:crop(pixel_width, cropped_pixel_height, 0, crop_offset_top)
 
-        local tmp_path = state.tmp_dir .. "/" .. utils.base64.encode(image.id) .. "-cropped-" .. crop_hash .. ".png"
+        local tmp_path = state.tmp_dir
+          .. "/"
+          .. utils.base64.encode(image.id)
+          .. "-"
+          .. image.date_hash
+          .. "-cropped-"
+          .. crop_hash
+          .. ".png"
         cropped_image:write(tmp_path)
         cropped_image:destroy()
 
@@ -372,7 +410,7 @@ local render = function(image)
 
         image.crop_hash = crop_hash
 
-        cache.cropped[image.path .. ":" .. crop_hash] = image.cropped_path
+        cache.cropped[image.path .. ":" .. image.date_hash .. ":" .. crop_hash] = image.cropped_path
       end
     end
   elseif needs_crop then
@@ -389,6 +427,7 @@ local render = function(image)
     and image.rendered_geometry.y == rendered_geometry.y
     and image.rendered_geometry.width == rendered_geometry.width
     and image.rendered_geometry.height == rendered_geometry.height
+    and image.date_hash == initial_date_hash
     and image.crop_hash == initial_crop_hash
     and image.resize_hash == initial_resize_hash
   then

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -39,6 +39,7 @@
 ---@field window_overlap_clear_enabled? boolean
 ---@field window_overlap_clear_ft_ignore? string[]
 ---@field editor_only_render_when_focused? boolean
+---@field check_image_changes_at_cursor? boolean
 ---@field tmux_show_only_in_active_window? boolean
 ---@field hijack_file_patterns? string[]
 
@@ -79,6 +80,7 @@
 ---@field crop fun(self: MagickImage, width: number, height: number, x?: number, y?: number)
 ---@field destroy fun(self: MagickImage)
 ---@field get_format fun(self: MagickImage): string
+---@field get_property fun(self: MagickImage, property: string): string
 ---@field get_height fun(self: MagickImage): number
 ---@field get_width fun(self: MagickImage): number
 ---@field modulate fun(self: MagickImage, brightness?: number, saturation?: number, hue?: number)


### PR DESCRIPTION
By default image updates are disabled, but when `check_image_changes_at_cursor` is set to `true`, it will be possible to check for changes in the image under the cursor. 
This way the performance hit from this option even when enabled should be minimal and will not scale with the amount of images displayed in the buffer. 
In order to refresh an image an user will need to place its cursor on the image line and force a render (I use `:e!`)