### PR TITLE
fix: corruption in large images when using ssh

### DIFF
--- a/lua/image/backends/kitty/helpers.lua
+++ b/lua/image/backends/kitty/helpers.lua
@@ -1,6 +1,10 @@
 local codes = require("image/backends/kitty/codes")
 local utils = require("image/utils")
 
+local uv = vim.uv
+ -- Allow for loop to be used on older versions
+if not uv then uv = vim.loop end
+
 local stdout = vim.loop.new_tty(1, false)
 if not stdout then error("failed to open stdout") end
 
@@ -45,7 +49,7 @@ local move_cursor = function(x, y, save)
   end
   if save then write("\x1b[s") end
   write("\x1b[" .. y .. ";" .. x .. "H")
-  vim.loop.sleep(1)
+  uv.sleep(1)
 end
 
 local restore_cursor = function()
@@ -92,6 +96,7 @@ local write_graphics = function(config, data)
       else
         control_payload = "m=1"
       end
+      uv.sleep(1)
     end
   else
     -- utils.debug("kitty control payload:", control_payload)


### PR DESCRIPTION
Potential fix for #95 . When using ssh, larger images have a chance of corrupting and displaying base64 strings as opposed to rendering the image. Through some testing, adding a sleep call to `write_graphics` seems to fix this issue. Earlier testing showed that it could still occur, but for some time I haven't run into this issue at all.

Hoping to get some feedback on whether this fixes the issue for anyone else.

Issue can be recreated by using `ssh localhost` as this still uses direct-mode. Then, attempting to render a large image (threshold varies from 30kb to 1mb) will sometimes cause base64 text to be displayed instead of the image. Config settings `max_width = nil`, `max_height = nil`, `max_width_window_percentage = math.huge` and `max_height_window_percentage = math.huge` minimize the chance that the image will be resized below the byte threshold for corruption.