### PR TITLE
feat: track col position for extmarks

### DIFF
--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -310,14 +310,17 @@ api.setup = function(options)
   end
 
   -- sync with extmarks
-  vim.api.nvim_create_autocmd({ "BufWritePost", "TextChanged", "TextChangedI" }, {
+  vim.api.nvim_create_autocmd({ "BufWritePost", "TextChanged", "TextChangedI", "InsertEnter" }, {
     group = group,
     callback = function(event)
       local images = api.get_images({ buffer = event.buf })
       for _, img in ipairs(images) do
-        local has_moved, extmark_y = img:has_extmark_moved()
-        if has_moved and extmark_y ~= nil then
-          img.geometry.y = extmark_y + 1
+        local has_moved, extmark_y, extmark_x = img:has_extmark_moved()
+        if has_moved and extmark_x and extmark_y then
+          img.geometry.y = extmark_y
+          img.geometry.x = extmark_x
+          img.extmark.col = extmark_x
+          img.extmark.row = extmark_y
           img:render()
         end
       end

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -148,6 +148,11 @@ local render = function(image)
 
   local absolute_x = original_x + x_offset + window_offset_x
   local absolute_y = original_y + y_offset + window_offset_y
+
+  if image.with_virtual_padding then
+    absolute_y = absolute_y + 1
+  end
+
   local prevent_rendering = false
 
   -- utils.debug(("(4) x: %d, y: %d, width: %d, height: %d y_offset: %d absolute_x: %d absolute_y: %d"):format( original_x, original_y, width, height, y_offset, absolute_x, absolute_y))

--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -81,7 +81,7 @@ local create_document_integration = function(config)
         local render_image = function(image)
           image:render({
             x = item.match.range.start_col,
-            y = item.match.range.start_row + 1,
+            y = item.match.range.start_row,
           })
         end
 

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -115,7 +115,7 @@
 ---@field saturation fun(self: Image, saturation: number)
 ---@field hue fun(self: Image, hue: number)
 ---@field namespace? string
----@field extmark? { id: number, row: number }
+---@field extmark? { id: number, row: number, col: number }
 
 -- wish proper generics were a thing here
 ---@class IntegrationContext


### PR DESCRIPTION
- fixes #157
- fixes an 'issue'[^2] where images were rendered one line lower than their extmark was positioned.
- fixes an issue where `o` would not update inline image positions (b/c it moves lines but doesn't count as `textchangedi`, only `insertenter`

[^2]: issue in quotes b/c it was intentional, and worked fine for document integrations

Changes a few things. Notably, we render images at the exact extmark position instead of one line lower. This causes some issues with the document integrations or rather, with virtually padded images in general, so now there's a check before rendering that causes images with virtual padding to render one line below their extmark, and this is likely the desired behavior.

tested with document integrations, my experimental latex renderer for neorg, and molten.

Causes an 'issue' with multiple virtually padded images on the same line where they each get their own padding, which looks unexpected. Fixing that issue would likely require a lot of new ugly code. 
considering that this would be rare, and that it's fixing a worse bug (image positions never updating), I think this behavior is acceptable.
