### PR TITLE
fix: account for char with multiple conceal hl

### DIFF
--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -301,7 +301,10 @@ local render = function(image)
               { semantic_tokens = false, syntax = false, extmarks = false, treesitter = true }
             )
             for _, hl in ipairs(res.treesitter) do
-              if hl.capture == "conceal" and not extmark_concealed[i + 1] then sum = sum + 1 end
+              if hl.capture == "conceal" and not extmark_concealed[i + 1] then
+                sum = sum + 1
+                break
+              end
             end
           end
           extmark_x_offset = extmark_x_offset - sum


### PR DESCRIPTION
Something that I missed in #156.

Some chars can have more than one highlight that conceals them, and these were being double counted, this doesn't happen anymore.
