### PR TITLE
Fix typo in pacman command

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ package as well.
     `export DYLD_LIBRARY_PATH="$(brew --prefix)/lib:$DYLD_LIBRARY_PATH"`
     to your shell profile (probably `.zshrc` or `.bashrc`)
 - Fedora: `sudo dnf install ImageMagick-devel`
-- Arch: `sudo pacman -Syy imagemagick`
+- Arch: `sudo pacman -Syu imagemagick`
 
 ## Configuration
 


### PR DESCRIPTION
This fixes a potentially dangerous typo in the pacman command for installing ImageMagick. `pacman -Sy somepackage` [should never be run without `-u`][1], as it could - worst case - lead to complete system breakage and the inability to boot.

[1]: https://wiki.archlinux.org/title/Pacman#Installing_packages
