### PR TITLE
feat: curl always redirect

### DIFF
--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -357,7 +357,7 @@ local from_url = function(url, options, callback, state)
   local stdout = vim.loop.new_pipe()
 
   vim.loop.spawn("curl", {
-    args = { "-s", "-o", tmp_path, url },
+    args = { "-L", "-s", "-o", tmp_path, url },
     stdio = { nil, stdout, nil },
     hide = true,
   }, function(code, signal)


### PR DESCRIPTION
I'm using `image.nvim` with norg, the current plugin isn't support when url is expected will be redirecedt.

Example:
* A: `.image https://github.com/r17x.png` -- current plugin not supported
* B: `.image https://github.com/r17x.png` -- in PR, plugin will supported. But, user will be configure with the property `curl_follow_redirect =  true`


### Changes
* add new option when run `require('image').setup({ ..., curl_follow_redirect = true })` -- *default*: `false`

### Preview
<img width="1432" alt="image" src="https://github.com/3rd/image.nvim/assets/16365952/5b19abef-2ce4-4011-9f3c-9f66ed16eece">
