### PR TITLE
add support for AVIF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ require("image").setup({
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "" },
   editor_only_render_when_focused = false, -- auto show/hide images when the editor gains/looses focus
   tmux_show_only_in_active_window = false, -- auto show/hide images in the correct Tmux window (needs visual-activity off)
-  hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp" }, -- render image files as images when opened
+  hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp", "*.avif" }, -- render image files as images when opened
 })
 ```
 

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -30,7 +30,7 @@ local default_options = {
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "scrollview", "scrollview_sign" },
   editor_only_render_when_focused = false,
   tmux_show_only_in_active_window = false,
-  hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp" },
+  hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp", "*.avif" },
 }
 
 ---@type State


### PR DESCRIPTION
- I found out `.avif` images are not supported by asking in discord   
  - `https://discord.com/channels/1178095355548680222/1178098370468921465/1245884208384315455`
- Modified code locally and tested, and I'm able to render `.avif` images
- Compared 2 different `.avif` files 
- Noticed that their first line was different
  - `0000 001c 6674 7970 6176 6966 0000 0000`
  - `0000 0020 6674 7970 6176 6966 0000 0000`
  - The first 4 bytes (0000 001c) and (0000 0020) represent the box size
  - The next 4 bytes (6674 7970) represent the box type
    - 6674 7970 in ASCII is "ftyp"
  - The next 4 bytes (6176 6966) represent the brand
    - 6176 6966 in ASCII is "avif"
- So I'm skipping the first 4 characters and detecting `ftypavif`
- If there's a better way, please feel free to apply the necessary changes