### PR TITLE
fix image and laststatus=2 overlap

### DIFF
--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -321,7 +321,7 @@ local render = function(image)
   -- clear out of bounds images
   if
       absolute_y + height <= bounds.top
-      or absolute_y >= bounds.bottom
+      or absolute_y >= bounds.bottom + (vim.o.laststatus == 2 and 1 or 0)
       or absolute_x + width <= bounds.left
       or absolute_x >= bounds.right
   then

--- a/lua/image/utils/window.lua
+++ b/lua/image/utils/window.lua
@@ -33,7 +33,7 @@ local get_windows = function(opts)
       rect = {
         top = pos[1],
         right = pos[2] + columns,
-        bottom = pos[1] + rows,
+        bottom = pos[1] + rows - (vim.o.laststatus == 2 and 1 or 0),
         left = pos[2],
       },
       masks = {},


### PR DESCRIPTION
This fixes an issue where the image overlaps with the statusline  when laststatus=2: each window has it's own statusline.

Refer to https://github.com/3rd/image.nvim/issues/179
