### PR TITLE
feat: add rockspec to avoid needs of extra plugins on Lazy >= v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ Fully **optional:**
 
 <summary>Lazy.nvim</summary>
 
+> Since version v11.* of Lazy rockspec is supported, so no need of extra plugins `vhyrro/luarocks.nvim`
+
+<details>
+<summary><b>Lazy >= v11.*</b></summary>
+
+```lua
+{
+    "3rd/image.nvim",
+    config = function()
+        -- ...
+    end
+}
+```
+</details>
+
+<details>
+<summary><b>Lazy < v11.x</b></summary>
+
 **NOTE:** Don't forget to install the imageMagick system package, detailed [below](#installing-imagemagick)
 
 It's recommended that you use [vhyrro/luarocks.nvim](https://github.com/vhyrro/luarocks.nvim) to
@@ -62,6 +80,7 @@ install luarocks for neovim while using lazy. But you can install manually as we
     end
 }
 ```
+</details>
 
 ---
 

--- a/image.nvim-scm-1.rockspec
+++ b/image.nvim-scm-1.rockspec
@@ -1,0 +1,37 @@
+local modrev, specrev = "scm", "-1"
+
+local repo_url = "https://github.com/kevinm6/image.nvim"
+local git_ref = "59d35492342f4afd74d74961cb9aafdb7caf29b9"
+
+rockspec_format = "3.0"
+package = "image.nvim"
+version = modrev .. specrev
+
+description = {
+  summary = "🖼️ Bringing images to Neovim.",
+  detailed = "",
+  labels = { "neovim", "neovim-plugin" },
+  homepage = repo_url,
+  license = "MIT",
+}
+
+dependencies = {
+  "lua >= 5.1",
+  "magick",
+}
+
+source = {
+  url = repo_url .. "/archive/" .. git_ref .. ".zip",
+  dir = "image.nvim-" .. "59d35492342f4afd74d74961cb9aafdb7caf29b9",
+}
+
+if modrev == "scm" or modrev == "dev" then source = {
+  url = repo_url:gsub("https", "git"),
+} end
+
+test_dependencies = {}
+
+build = {
+  type = "builtin",
+  copy_directories = {},
+}


### PR DESCRIPTION
since [Lazy v11.x](https://github.com/folke/lazy.nvim/pull/1530), Lazy supports **rockspec**, so extra plugins like `vhyrro/luarocks.nvim` are no more required.

This **PR** add the updated **README** for **Lazy** version >= 11.x and the `rockspec` file [required by Lazy](https://lazy.folke.io/packages) to install the relative luarocks.

This file should be easy to update via **GHActions** as another [action is performed](https://github.com/3rd/image.nvim/actions/workflows/luarocks.yml) to create the same for luarocks.