### PR TITLE
fix(kitty): image shown when switching to different tmux session #198

### DIFF
--- a/lua/image/backends/kitty/init.lua
+++ b/lua/image/backends/kitty/init.lua
@@ -165,12 +165,14 @@ backend.clear = function(image_id, shallow)
     if not image then return end
 
     if image.is_rendered then
+      local tty = get_clear_tty_override()
+      if tty == nil then tty = utils.tmux.get_active_pane_tty() end
       helpers.write_graphics({
         action = codes.control.action.delete,
         display_delete = "i",
         image_id = image.internal_id,
         quiet = 2,
-        tty = get_clear_tty_override(),
+        tty = tty,
       })
     end
 

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -258,6 +258,7 @@ api.setup = function(options)
   then
     local images_to_restore_on_focus = {}
     local initial_tmux_window_id = utils.tmux.get_window_id()
+    local initial_tmux_session = utils.tmux.get_current_session()
 
     vim.api.nvim_create_autocmd("FocusLost", {
       group = group,
@@ -268,6 +269,7 @@ api.setup = function(options)
           if
             state.options.editor_only_render_when_focused
             or (utils.tmux.is_tmux and utils.tmux.get_window_id() ~= initial_tmux_window_id)
+            or (utils.tmux.is_tmux and utils.tmux.get_attached_session() ~= initial_tmux_session)
           then
             state.disable_decorator_handling = true
 

--- a/lua/image/utils/tmux.lua
+++ b/lua/image/utils/tmux.lua
@@ -14,6 +14,20 @@ local create_dm_getter = function(name)
   end
 end
 
+local get_active_pane_tty = function()
+  if not is_tmux then return nil end
+  local result = vim.fn.system(
+    "tmux list-sessions -F '#{session_name} #{session_attached}' | awk '$2 == \"1\" {print $1}' | xargs -I{} tmux list-panes -t {} -F '#{pane_active} #{pane_tty}' | awk '$1 == \"1\" {print $2}'"
+  )
+  return vim.fn.trim(result)
+end
+
+local get_attached_session = function()
+  if not is_tmux then return nil end
+  local result = vim.fn.system("tmux list-sessions | grep \"(attached)\" | sed -E 's/:.*$//'")
+  return vim.fn.trim(result)
+end
+
 local escape = function(sequence)
   return "\x1bPtmux;" .. sequence:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
 end
@@ -23,10 +37,13 @@ return {
   has_passthrough = has_passthrough,
   get_pid = create_dm_getter("pid"),
   get_socket_path = create_dm_getter("socket_path"),
+  get_attached_session = get_attached_session,
+  get_current_session = create_dm_getter("session_name"),
   get_window_id = create_dm_getter("window_id"),
   get_window_name = create_dm_getter("window_name"),
   get_pane_id = create_dm_getter("pane_id"),
   get_pane_pid = create_dm_getter("pane_pid"),
+  get_active_pane_tty = get_active_pane_tty,
   get_pane_tty = create_dm_getter("pane_tty"),
   get_cursor_x = create_dm_getter("cursor_x"),
   get_cursor_y = create_dm_getter("cursor_y"),


### PR DESCRIPTION
fixes #198

steps to verify PR on issue above.

Approach:
1. detect and clear image when attached session has changed
2. detect and clear currently active pane tty across sessions