### PR TITLE
backends/kitty: Drop fractional portions when stringifying numbers

### DIFF
--- a/lua/image/backends/kitty/helpers.lua
+++ b/lua/image/backends/kitty/helpers.lua
@@ -75,7 +75,20 @@ local write_graphics = function(config, data)
   for k, v in pairs(config) do
     if v ~= nil then
       local key = codes.control.keys[k]
-      if key then control_payload = control_payload .. key .. "=" .. v .. "," end
+      if key then
+        if type(v) == "number" then
+          -- There are currently no floating-point values in the Kitty graphics
+          -- specification. All values are either signed or unsigned 32-bit integers.
+          -- As such, we just stringify the number values here using "%d" to drop any
+          -- possible fractional portions.
+          --
+          -- (Note that string.format here is used to accommodate older versions of
+          -- Lua, in addition to the fact that we are just writing the string below
+          -- anyway).
+          v = string.format("%d", v)
+        end
+        control_payload = control_payload .. key .. "=" .. v .. ","
+      end
     end
   end
   control_payload = control_payload:sub(0, -2)


### PR DESCRIPTION
The Kitty graphics specification currently does not contain any non-integer number types (just signed and unsigned 32-bit int; see https://sw.kovidgoyal.net/kitty/graphics-protocol/#control-data-reference). In some terminals (read: [Ghostty](https://mitchellh.com/ghostty)), the resulting technically malformed message will result in unexpected behavior (currently manifesting as random display issues due to the non-determinism in the sending of control key/value pairs).

This commit fixes this by ensuring that all number values only have their whole portion rendered, to accomplish this we just use `string.format` with `"%d"`.