### PR TITLE
fix: more reliably hijack buffer

### DIFF
--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -306,7 +306,7 @@ api.setup = function(options)
 
   -- hijack image filetypes
   if state.options.hijack_file_patterns and #state.options.hijack_file_patterns > 0 then
-    vim.api.nvim_create_autocmd({ "BufRead", "WinEnter", "BufWinEnter" }, {
+    vim.api.nvim_create_autocmd("BufReadCmd", {
       group = group,
       pattern = state.options.hijack_file_patterns,
       callback = function(event)


### PR DESCRIPTION
I've experienced some unreliability when hijacking buffers when entering them after having already entered them. Using `BufReadCmd` seems more appropriate since this overwrites how the buffer is displayed entirely.
