### PR TITLE
Add TMUX session agnostic status getters

### DIFF
--- a/lua/image/utils/tmux.lua
+++ b/lua/image/utils/tmux.lua
@@ -14,6 +14,26 @@ local create_dm_getter = function(name)
   end
 end
 
+local create_dm_window_getter = function(name)
+  return function()
+    if not is_tmux then return nil end
+    local result = vim.fn.system(
+      "tmux list-windows -t $(tmux display-message -p '#{client_session}') -F '#{" .. name .. "}' -f '#{window_active}'"
+    )
+    return vim.fn.trim(result)
+  end
+end
+
+local create_dm_pane_getter = function(name)
+  return function()
+    if not is_tmux then return nil end
+    local result = vim.fn.system(
+      "tmux list-panes -t $(tmux display-message -p '#{client_session}') -F '#{" .. name .. "}' -f '#{pane_active}'"
+    )
+    return vim.fn.trim(result)
+  end
+end
+
 local escape = function(sequence)
   return "\x1bPtmux;" .. sequence:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
 end
@@ -23,12 +43,12 @@ return {
   has_passthrough = has_passthrough,
   get_pid = create_dm_getter("pid"),
   get_socket_path = create_dm_getter("socket_path"),
-  get_current_session = create_dm_getter("session_name"),
-  get_window_id = create_dm_getter("window_id"),
-  get_window_name = create_dm_getter("window_name"),
-  get_pane_id = create_dm_getter("pane_id"),
-  get_pane_pid = create_dm_getter("pane_pid"),
-  get_pane_tty = create_dm_getter("pane_tty"),
+  get_current_session = create_dm_getter("client_session"),
+  get_window_id = create_dm_window_getter("window_id"),
+  get_window_name = create_dm_window_getter("window_name"),
+  get_pane_id = create_dm_pane_getter("pane_id"),
+  get_pane_pid = create_dm_pane_getter("pane_pid"),
+  get_pane_tty = create_dm_pane_getter("pane_tty"),
   get_cursor_x = create_dm_getter("cursor_x"),
   get_cursor_y = create_dm_getter("cursor_y"),
   escape = escape,


### PR DESCRIPTION
This should help solve the issues with images not being cleared correctly.

Basically, `#session_name` and the other ways of getting active TMUX session info that is currently present in image.nvim is limited by the fact that they will always scope the result based on the session from within which the command is being run. The right way to get the actually active session name of the current client is `#client_session`. We can then use that in combination with `list-windows` and `list-panes` in order to get the currently active pane/window of the active session.