### PR TITLE
Added support for the typst language

### DIFF
--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -8,6 +8,9 @@ local default_options = {
     markdown = {
       enabled = true,
     },
+    typst = {
+      enabled = true,
+    },
     neorg = {
       enabled = true,
     },

--- a/lua/image/integrations/typst.lua
+++ b/lua/image/integrations/typst.lua
@@ -1,0 +1,46 @@
+local document = require("image/utils/document")
+return document.create_document_integration({
+  name = "typst",
+  -- debug = true,
+  default_options = {
+    clear_in_insert_mode = false,
+    download_remote_images = true,
+    only_render_image_at_cursor = false,
+    filetypes = { "typst" },
+  },
+  query_buffer_images = function(buffer)
+    local buf = buffer or vim.api.nvim_get_current_buf()
+
+    local parser = vim.treesitter.get_parser(buf, "typst")
+    local root = parser:parse()[1]:root()
+    local query =
+      vim.treesitter.query.parse("typst", '(call item: (ident) @name (#eq? @name "image") (group (string) @url))')
+
+    local images = {}
+    local current_image = nil
+
+    ---@diagnostic disable-next-line: missing-parameter
+    for id, node in query:iter_captures(root, 0) do
+      local capture = query.captures[id]
+      local value = vim.treesitter.get_node_text(node, buf)
+
+      if capture == "name" then
+        -- Get the parent since we want the "call" and not only the "ident"
+        local start_row, start_col, end_row, end_col = node:parent():range()
+        current_image = {
+          node = node,
+          range = { start_row = start_row, start_col = start_col, end_row = end_row, end_col = end_col },
+        }
+      elseif current_image and capture == "url" then
+        -- We need to remove the quotes from the string
+        -- '"The URL"' -> "The URL"
+        current_image.url = string.sub(value, 2, -2)
+
+        table.insert(images, current_image)
+        current_image = nil
+      end
+    end
+
+    return images
+  end,
+})


### PR DESCRIPTION
Good evening,
I have added support for the [Typst](https://github.com/typst/typst) language, a modern alternative to LaTeX.

The implementation is tested and functional, with images displaying correctly. 

<img width="1211" alt="Screenshot 2024-10-02 at 01 53 28" src="https://github.com/user-attachments/assets/53942085-e78b-4287-b54d-aa66bdc22642">

Thank you for your time and for maintaining such a fantastic plugin!
Best regards,
Etienne