### PR TITLE
docs: correct installation instructions for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ package as well.
 - MacOS:
   - Homebrew: `brew install imagemagick`
     - By default, homebrew installs into a weird location, so you have to add `$(brew --prefix)/lib` to
-    `DYLD_LIBRARY_PATH` by adding something like
-    `export DYLD_LIBRARY_PATH="$(brew --prefix)/lib:$DYLD_LIBRARY_PATH"`
+    `DYLD_FALLBACK_LIBRARY_PATH` by adding something like
+    `export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix)/lib:$DYLD_FALLBACK_LIBRARY_PATH"`
     to your shell profile (probably `.zshrc` or `.bashrc`)
   - MacPorts: `sudo port install imagemagick`
-    - You must add `/opt/local/lib` to `DYLD_LIBRARY_PATH`, similar to homebrew.
+    - You must add `/opt/local/lib` to `DYLD_FALLBACK_LIBRARY_PATH`, similar to homebrew.
 - Fedora: `sudo dnf install ImageMagick-devel`
 - Arch: `sudo pacman -Syu imagemagick`
 


### PR DESCRIPTION
Once I set `DYLD_LIBRARY_PATH`, other things stopped working, like `ffmpeg`. I was playing around with `package.cpath` but that didn't seem to work. I found this [stack overflow thread](https://stackoverflow.com/questions/3146274/is-it-ok-to-use-dyld-library-path-on-mac-os-x-and-whats-the-dynamic-library-s) where it's recommended to use `DYLD_FALLBACK_LIBRARY_PATH` which has worked wonders for me. Updating the documentation in this PR for future readers.
