### PR TITLE
docs: fix nesting and indent of lazy.nvim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ Fully **optional:**
 
 ```lua
 require("lazy").setup({
-    "3rd/image.nvim",
-    config = function()
-        -- ...
-    end
+    {
+        "3rd/image.nvim",
+        config = function()
+            -- ...
+        end
+    },
 }, {
     rocks = {
         hererocks = true,  -- recommended if you do not have global installation of Lua 5.1.


### PR DESCRIPTION
Sorry, I messed up table nesting in `lazy.nvim` configuration by mistake (in #236).
`config` should belong to `image.nvim` plugin spec, not directly to first arg of `lazy.setup()`.