### PR TITLE
add image signature for pdf

### DIFF
--- a/lua/image/utils/magic.lua
+++ b/lua/image/utils/magic.lua
@@ -10,6 +10,7 @@ local image_signatures = {
   AVIF = "\x66\x74\x79\x70\x61\x76\x69\x66",
   SVG = "<svg",
   XML = "<?xml",
+  PDF = "%PDF",
 }
 
 local function read_file_header(file, num_bytes)


### PR DESCRIPTION
imagemagick can convert pdf files to png withouth problem. The only thing that prevents support for pdf files seems to be them not being recognized as an image type by `is_image()`. Adding a single line to `magic.lua` should resolve this.