### PR TITLE
Add support for base64 encoded images

### DIFF
--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -12,7 +12,7 @@ end
 
 local resolve_base64_image = function(document_file_path, image_path)
   local tmp_b64_path = vim.fn.tempname()
-  local base64_part = string.sub(image_path, 23)
+  local base64_part = image_path:gsub("^data:image/[%w%+]+;base64,", "")
   local decoded = vim.base64.decode(base64_part)
 
   local file = io.open(tmp_b64_path, "wb")

--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -12,8 +12,15 @@ end
 
 local resolve_base64_image = function(document_file_path, image_path)
   local tmp_b64_path = vim.fn.tempname()
-  vim.fn.writefile({ image_path }, tmp_b64_path)
-  os.execute("convert inline:" .. tmp_b64_path .. " " .. tmp_b64_path)
+  local base64_part = string.sub(image_path, 23)
+  local decoded = vim.base64.decode(base64_part)
+
+  local file = io.open(tmp_b64_path, "wb")
+  if file ~= nil then
+    file:write(decoded)
+    file:close()
+  end
+
   return tmp_b64_path
 end
 

--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -10,6 +10,13 @@ local resolve_absolute_path = function(document_file_path, image_path)
   return absolute_image_path
 end
 
+local resolve_base64_image = function(document_file_path, image_path)
+  local tmp_b64_path = vim.fn.tempname()
+  vim.fn.writefile({ image_path }, tmp_b64_path)
+  os.execute("convert inline:" .. tmp_b64_path .. " " .. tmp_b64_path)
+  return tmp_b64_path
+end
+
 local is_remote_url = function(url)
   return string.sub(url, 1, 7) == "http://" or string.sub(url, 1, 8) == "https://"
 end
@@ -108,6 +115,8 @@ local create_document_integration = function(config)
           local path
           if ctx.options.resolve_image_path then
             path = ctx.options.resolve_image_path(item.file_path, item.match.url, resolve_absolute_path)
+          elseif string.sub(item.match.url, 1, 10) == "data:image" then
+            path = resolve_base64_image(item.file_path, item.match.url)
           else
             path = resolve_absolute_path(item.file_path, item.match.url)
           end


### PR DESCRIPTION
Closes #135 

Currently, image.nvim doesn't support base64 encoded images such as this one:
```markdown
![my_image](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANwAAADcCAYAAAAbWs+BAAAGwElEQVR4Ae3cwZFbNxBFUY5rkrDTmKAUk5QT03Aa44U22KC7NHptw+DRikVAXf8fzC3u8Hj4R4AAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAgZzAW26USQT+e4HPx+Mz+RRvj0e0kT+SD2cWAQK1gOBqH6sEogKCi3IaRqAWEFztY5VAVEBwUU7DCNQCgqt9rBKICgguymkYgVpAcLWPVQJRAcFFOQ0jUAsIrvaxSiAqILgop2EEagHB1T5WCUQFBBflNIxALSC42scqgaiA4KKchhGoBQRX+1glEBUQXJTTMAK1gOBqH6sEogKCi3IaRqAWeK+Xb1z9iN558fHxcSPS9p2ezx/ROz4e4TtIHt+3j/61hW9f+2+7/+UXbifjewIDAoIbQDWSwE5AcDsZ3xMYEBDcAKqRBHYCgtvJ+J7AgIDgBlCNJLATENxOxvcEBgQEN4BqJIGdgOB2Mr4nMCAguAFUIwnsBAS3k/E9gQEBwQ2gGklgJyC4nYzvCQwICG4A1UgCOwHB7WR8T2BAQHADqEYS2AkIbifjewIDAoIbQDWSwE5AcDsZ3xMYEEjfTzHwiK91B8npd6Q8n8/oGQ/ckRJ9vvQwv3BpUfMIFAKCK3AsEUgLCC4tah6BQkBwBY4lAmkBwaVFzSNQCAiuwLFEIC0guLSoeQQKAcEVOJYIpAUElxY1j0AhILgCxxKBtIDg0qLmESgEBFfgWCKQFhBcWtQ8AoWA4AocSwTSAoJLi5pHoBAQXIFjiUBaQHBpUfMIFAKCK3AsEUgLCC4tah6BQmDgTpPsHSTFs39p6fQ7Q770UsV/Ov19X+2OFL9wxR+rJQJpAcGlRc0jUAgIrsCxRCAtILi0qHkECgHBFTiWCKQFBJcWNY9AISC4AscSgbSA4NKi5hEoBARX4FgikBYQXFrUPAKFgOAKHEsE0gKCS4uaR6AQEFyBY4lAWkBwaVHzCBQCgitwLBFICwguLWoegUJAcAWOJQJpAcGlRc0jUAgIrsCxRCAt8J4eePq89B0ar3ZnyOnve/rfn1+400/I810lILirjtPLnC4guNNPyPNdJSC4q47Ty5wuILjTT8jzXSUguKuO08ucLiC400/I810lILirjtPLnC4guNNPyPNdJSC4q47Ty5wuILjTT8jzXSUguKuO08ucLiC400/I810lILirjtPLnC4guNNPyPNdJSC4q47Ty5wuILjTT8jzXSUguKuO08ucLiC400/I810l8JZ/m78+szP/zI47fJo7Q37vgJ7PHwN/07/3TOv/9gu3avhMYFhAcMPAxhNYBQS3avhMYFhAcMPAxhNYBQS3avhMYFhAcMPAxhNYBQS3avhMYFhAcMPAxhNYBQS3avhMYFhAcMPAxhNYBQS3avhMYFhAcMPAxhNYBQS3avhMYFhAcMPAxhNYBQS3avhMYFhAcMPAxhNYBQS3avhMYFhAcMPAxhNYBQS3avhMYFhg4P6H9J0maYHXuiMlrXf+vOfA33Turf3C5SxNItAKCK4lsoFATkBwOUuTCLQCgmuJbCCQExBcztIkAq2A4FoiGwjkBASXszSJQCsguJbIBgI5AcHlLE0i0AoIriWygUBOQHA5S5MItAKCa4lsIJATEFzO0iQCrYDgWiIbCOQEBJezNIlAKyC4lsgGAjkBweUsTSLQCgiuJbKBQE5AcDlLkwi0Akff//Dz6U+/I6U1/sUNr3bnytl3kPzi4bXb/cK1RDYQyAkILmdpEoFWQHAtkQ0EcgKCy1maRKAVEFxLZAOBnIDgcpYmEWgFBNcS2UAgJyC4nKVJBFoBwbVENhDICQguZ2kSgVZAcC2RDQRyAoLLWZpEoBUQXEtkA4GcgOByliYRaAUE1xLZQCAnILicpUkEWgHBtUQ2EMgJCC5naRKBVkBwLZENBHIC/4M7TXIv+3PS22d24qvdQfL3C/7N5P5i/MLlLE0i0AoIriWygUBOQHA5S5MItAKCa4lsIJATEFzO0iQCrYDgWiIbCOQEBJezNIlAKyC4lsgGAjkBweUsTSLQCgiuJbKBQE5AcDlLkwi0AoJriWwgkBMQXM7SJAKtgOBaIhsI5AQEl7M0iUArILiWyAYCOQHB5SxNItAKCK4lsoFATkBwOUuTCBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIDAvyrwDySEJ2VQgUSoAAAAAElFTkSuQmCC)
```

This PR attempts to solve this problem by saving the image data to a temp file and return the corresponding temporary path.

_PS: I've realized that there has been a work on base64 encoded images in the repository, but when I tried to display an image (without any further configuration), I failed to get it working._

---

Thanks for the awesome project!