### PR TITLE
feat: add floating_windows integration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ require("image").setup({
       clear_in_insert_mode = false,
       download_remote_images = true,
       only_render_image_at_cursor = false,
+      floating_windows = false, -- if true, images will be rendered in floating markdown windows
       filetypes = { "markdown", "vimwiki" }, -- markdown extensions (ie. quarto) can go here
     },
     neorg = {

--- a/lua/image/integrations/css.lua
+++ b/lua/image/integrations/css.lua
@@ -6,6 +6,7 @@ return document.create_document_integration({
     clear_in_insert_mode = false,
     download_remote_images = true,
     only_render_image_at_cursor = false,
+    floating_windows = false,
     filetypes = { "css", "sass", "scss" },
   },
   query_buffer_images = function(buffer)

--- a/lua/image/integrations/html.lua
+++ b/lua/image/integrations/html.lua
@@ -6,6 +6,7 @@ return document.create_document_integration({
     clear_in_insert_mode = false,
     download_remote_images = true,
     only_render_image_at_cursor = false,
+    floating_windows = false,
     filetypes = { "html", "xhtml", "htm" },
   },
   query_buffer_images = function(buffer)

--- a/lua/image/integrations/markdown.lua
+++ b/lua/image/integrations/markdown.lua
@@ -7,6 +7,7 @@ return document.create_document_integration({
     clear_in_insert_mode = false,
     download_remote_images = true,
     only_render_image_at_cursor = false,
+    floating_windows = false,
     filetypes = { "markdown", "vimwiki" },
   },
   query_buffer_images = function(buffer)

--- a/lua/image/integrations/neorg.lua
+++ b/lua/image/integrations/neorg.lua
@@ -23,6 +23,7 @@ return document.create_document_integration({
     clear_in_insert_mode = false,
     download_remote_images = true,
     only_render_image_at_cursor = false,
+    floating_windows = false,
     filetypes = { "norg" },
   },
   query_buffer_images = function(buffer)

--- a/lua/image/integrations/syslang.lua
+++ b/lua/image/integrations/syslang.lua
@@ -7,6 +7,7 @@ return document.create_document_integration({
     clear_in_insert_mode = false,
     download_remote_images = true,
     only_render_image_at_cursor = false,
+    floating_windows = false,
     filetypes = { "syslang" },
   },
   query_buffer_images = function(buffer)

--- a/lua/image/integrations/typst.lua
+++ b/lua/image/integrations/typst.lua
@@ -6,6 +6,7 @@ return document.create_document_integration({
     clear_in_insert_mode = false,
     download_remote_images = true,
     only_render_image_at_cursor = false,
+    floating_windows = false,
     filetypes = { "typst" },
   },
   query_buffer_images = function(buffer)

--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -50,7 +50,7 @@ local create_document_integration = function(config)
   local render = vim.schedule_wrap(
     ---@param ctx IntegrationContext
     function(ctx)
-      local windows = utils.window.get_windows({ normal = true })
+      local windows = utils.window.get_windows({ normal = true, floating = ctx.options.floating_windows })
 
       local image_queue = {}
 

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -26,6 +26,7 @@
 ---@field only_render_image_at_cursor? boolean
 ---@field filetypes? string[]
 ---@field resolve_image_path? function
+---@field floating_windows? boolean
 
 ---@alias IntegrationOptions DocumentIntegrationOptions
 


### PR DESCRIPTION
Allows rendering images in floating windows. My use-case is to render images in noice.nvim LSP hover documentation windows.