### PR TITLE
feat: added scale_factor for custom global scaling

### DIFF
--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -31,6 +31,7 @@ local default_options = {
   max_height = nil,
   max_width_window_percentage = 100,
   max_height_window_percentage = 50,
+  scale_factor = 1.0,
   kitty_method = "normal",
   window_overlap_clear_enabled = false,
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "scrollview", "scrollview_sign" },

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -11,8 +11,10 @@ local cache = {}
 local render = function(image)
   local state = image.global_state
   local term_size = utils.term.get_size()
-  local image_rows = math.floor(image.image_height / term_size.cell_height)
-  local image_columns = math.floor(image.image_width / term_size.cell_width)
+  local scale_factor = 1.0
+  if type(state.options.scale_factor) == "number" then scale_factor = state.options.scale_factor end
+  local image_rows = math.floor(image.image_height / term_size.cell_height * scale_factor)
+  local image_columns = math.floor(image.image_width / term_size.cell_width * scale_factor)
   local image_cache = cache[image.original_path] or { resized = {}, cropped = {} }
 
   -- utils.debug(("renderer.render() %s"):format(image.id), {

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -36,6 +36,7 @@
 ---@field max_height? number
 ---@field max_width_window_percentage? number
 ---@field max_height_window_percentage? number
+---@field scale_factor? number
 ---@field kitty_method "normal"|"unicode-placeholders"
 ---@field window_overlap_clear_enabled? boolean
 ---@field window_overlap_clear_ft_ignore? string[]


### PR DESCRIPTION
I added a global option `scale_factor`, so we can globally scale the image.

The default scale_factor is 1.0.
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/83da951c-c08e-46da-9794-7e4cfb055175">

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/c06463bc-a295-4716-b861-e95e57459570">


Now we can scale it to some other numbers.
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/f2f62d8b-c6f8-479e-bf0b-04d7d4daacbd">

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/3beab7c6-2d61-40e8-894a-e78701c4bf7f">

It seems working fine on my markdown and typst files. It also works with telescope preview.
