### PR TITLE
Also works for debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ sudo pacman -Syu imagemagick
 </details>
 
 <details>
-<summary>Ubuntu</summary>
+<summary>Ubuntu/Debian</summary>
 
 ```sh
 # for magick_cli


### PR DESCRIPTION
Tested with debian 12.

But, what was not mentioned was that I had to install luarocks (+magick through luarocks) before it worked.

But yeah, the installation of imagemagick worked with debian as well!