### PR TITLE
feat: add support for wrapping

### DIFF
--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -25,38 +25,6 @@ local createImage = function(template, global_state)
   return instance
 end
 
----@param o1 any|table First object to compare
----@param o2 any|table Second object to compare
----@param ignore_mt boolean True to ignore metatables (a recursive function to tests tables inside tables)
-local function equals(o1, o2, ignore_mt)
-  if o1 == o2 then return true end
-  local o1Type = type(o1)
-  local o2Type = type(o2)
-  if o1Type ~= o2Type then return false end
-  if o1Type ~= "table" then return false end
-
-  if not ignore_mt then
-    local mt1 = getmetatable(o1)
-    if mt1 and mt1.__eq then
-      --compare using built in method
-      return o1 == o2
-    end
-  end
-
-  local keySet = {}
-
-  for key1, value1 in pairs(o1) do
-    local value2 = o2[key1]
-    if value2 == nil or equals(value1, value2, ignore_mt) == false then return false end
-    keySet[key1] = true
-  end
-
-  for key2, _ in pairs(o2) do
-    if not keySet[key2] then return false end
-  end
-  return true
-end
-
 ---get the extmark id for the virtual padding for this image
 ---@return number?
 function Image:get_extmark_id()
@@ -75,23 +43,9 @@ function Image:has_extmark_moved()
   return false
 end
 
-local function save(data)
-  local enc = require("lua.helpers.json").encode(data)
-  print(enc)
-  vim.fn.setreg("+", enc)
-end
-
 ---@param geometry? ImageGeometry
 function Image:render(geometry)
-  -- if equals(geometry, self.geometry, true) then return end
-
   if geometry then self.geometry = vim.tbl_deep_extend("force", self.geometry, geometry) end
-
-  -- if geometry == nil then return end
-
-  save({ geometry, self.geometry })
-
-  -- save({ "yeah", self.geometry }) --
 
   -- don't render if we are in the conmmand-line-window, in this case previously rendered images can
   -- be left in place
@@ -124,7 +78,7 @@ function Image:render(geometry)
   -- utils.debug(("---------------- %s ----------------"):format(self.id))
   local was_rendered = renderer.render(self)
 
-  -- print(
+  -- utils.debug(
   --   ("[image] success: %s x: %s, y: %s, width: %s, height: %s"):format(
   --     was_rendered,
   --     self.geometry.x,
@@ -142,8 +96,8 @@ function Image:render(geometry)
 
   -- virtual padding
   if was_rendered and self.buffer and self.inline then
-    local row = self.geometry.y
-    local col = self.geometry.x
+    local row = self.geometry.row
+    local col = self.geometry.col
     local height = self.rendered_geometry.height
 
     local extmark_key = self.buffer .. ":" .. row .. ":" .. col

--- a/lua/image/integrations/markdown.lua
+++ b/lua/image/integrations/markdown.lua
@@ -36,10 +36,41 @@ return document.create_document_integration({
           -- TODO: fix node:range() taking into account the extmarks for SOME FKING REASON
           if key == "image" then
             local start_row, start_col, end_row, end_col = node:range()
+
             current_image = {
               node = node,
-              range = { start_row = start_row, start_col = start_col, end_row = end_row, end_col = end_col },
+              range = {
+                start_row = start_row,
+                start_col = start_col,
+                end_row = end_row,
+                end_col = end_col,
+              },
             }
+
+            -- -- start_{row, col} end_{row, col}
+            -- -- local res = node:range()
+            -- local start_pos = vim.fn.screenpos(buffer, start_row, start_col)
+            -- local end_pos = vim.fn.screenpos(buffer, end_row, end_col)
+            --
+            -- -- local function save(data)
+            -- --   vim.fn.setreg(tostring(buffer), require("lua.helpers.json").encode(data))
+            -- -- end
+            -- --
+            -- -- print(buffer, start_row, start_col) -- ,
+            -- -- save(vim.fn.screenpos(buffer, start_row, start_col))
+            -- current_image = {
+            --   node = node,
+            --   range = {
+            --     -- start_row = start_row,
+            --     -- start_col = start_col,
+            --     -- end_row = end_row,
+            --     -- end_col = end_col,
+            --     start_row = start_pos.row,
+            --     start_col = start_pos.col - vim.fn.win_screenpos(buffer)[1],
+            --     end_row = end_pos.row,
+            --     end_col = end_pos.col,
+            --   },
+            -- }
           elseif current_image and key == "url" then
             current_image.url = value
             table.insert(images, current_image)

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -62,7 +62,9 @@ local render = function(image)
   width = math.min(width, term_size.screen_cols)
   -- height = math.min(height, term_size.screen_rows)
 
-  -- utils.debug(("(1) x: %d, y: %d, width: %d, height: %d y_offset: %d"):format(original_x, original_y, width, height, y_offset))
+  -- utils.debug(
+  --   ("(1) x: %d, y: %d, width: %d, height: %d y_offset: %d"):format(original_x, original_y, width, height, y_offset)
+  -- )
 
   if image.window ~= nil then
     -- bail if the window is invalid
@@ -76,13 +78,22 @@ local render = function(image)
     end
 
     -- bail if the window is not visible
-    if not window.is_visible then return false end
+    if not window.is_visible then
+      utils.debug("windows not visible", image.id)
+      return false
+    end
 
     -- bail if the window is overlapped
-    if state.options.window_overlap_clear_enabled and #window.masks > 0 then return false end
+    if state.options.window_overlap_clear_enabled and #window.masks > 0 then
+      utils.debug("overlap", image.id)
+      return false
+    end
 
     -- if the image is tied to a buffer the window must be displaying that buffer
-    if image.buffer ~= nil and window.buffer ~= image.buffer then return false end
+    if image.buffer ~= nil and window.buffer ~= image.buffer then
+      utils.debug("bufffer not shown", image.id)
+      return false
+    end
 
     -- get topfill and check fold status
     local current_win = vim.api.nvim_get_current_win()
@@ -96,6 +107,7 @@ local render = function(image)
       -- utils.debug("image is inside a fold", image.id)
       state.images[image.id] = image
       image:clear(true)
+      utils.debug("inside fold")
       return false
     end
 
@@ -146,7 +158,10 @@ local render = function(image)
 
   width, height = utils.math.adjust_to_aspect_ratio(term_size, image.image_width, image.image_height, width, height)
 
-  if width <= 0 or height <= 0 then return false end
+  if width <= 0 or height <= 0 then
+    utils.debug("width & highy < 0")
+    return false
+  end
 
   -- utils.debug(("(3) x: %d, y: %d, width: %d, height: %d y_offset: %d"):format(original_x, original_y, width, height, y_offset))
 
@@ -161,7 +176,10 @@ local render = function(image)
 
   if image.window and image.buffer then
     local win_info = vim.fn.getwininfo(image.window)[1]
-    if not win_info then return false end
+    if not win_info then
+      utils.debug("no win info")
+      return false
+    end
     local topline = win_info.topline
     local botline = win_info.botline
 
@@ -331,6 +349,7 @@ local render = function(image)
     else
       state.images[image.id] = image
     end
+    utils.debug("out of bounds")
     return false
   end
 
@@ -447,7 +466,7 @@ local render = function(image)
   image.rendered_geometry = rendered_geometry
   cache[image.original_path] = image_cache
 
-  -- utils.debug("rendered", image)
+  utils.debug("rendered")
   return true
 end
 

--- a/lua/image/utils/logger.lua
+++ b/lua/image/utils/logger.lua
@@ -73,7 +73,7 @@ return {
   debug = create_logger({
     prefix = "[image.nvim]",
     formatter = default_log_formatter,
-    handler = nil,
+    handler = print,
     output_file = "/tmp/nvim-image.txt",
   }),
 }

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -59,6 +59,8 @@
 ---@class ImageGeometry
 ---@field x? number
 ---@field y? number
+---@field row? number
+---@field col? number
 ---@field width? number
 ---@field height? number
 


### PR DESCRIPTION
"fixes" #62 

Currently doesn't work for multiple windows (trying to fix that one) and it also causes some problems with detecting if it overlaps with the edges or not since the logic for that uses literal line numbers instead of the visual lines required for supporting wrapping. 

I think it might be easier to just rewrite the renderer.lua / document.lua / image.lua than to do that. Especially since vim.fn.screenpos() could probably simplify the logic of calculating the absolute position of the image. 

Btw this contains a lot of dbg stuff and im very new to actually doing things with lua outside of configuring neovim.
