### PR TITLE
fix: plugin configuration references on readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,14 +222,15 @@ After you've set up the dependencies, install the `image.nvim` plugin.
 
 ```lua
 require("lazy").setup({
-    {
-        "3rd/image.nvim",
-        opts = {}
-    },
-}, {
     rocks = {
         hererocks = true,  -- recommended if you do not have global installation of Lua 5.1.
     },
+    spec = {
+        {
+            "3rd/image.nvim",
+            opts = {}
+        },
+    }
 })
 ```
 
@@ -295,7 +296,9 @@ package.path = package.path .. ";" .. vim.fn.expand("$HOME") .. "/.luarocks/shar
 {
     "3rd/image.nvim",
     build = false, -- so that it doesn't build the rock https://github.com/3rd/image.nvim/issues/91#issuecomment-2453430239
-    opts = {}
+    opts = {
+        processor = "magick_cli",
+  }
 }
 ```
 


### PR DESCRIPTION
- Makes clear `rocks` is a `lazy.nvim` configuration option
- Adds `processor = "magick_cli"` as part of the right configuration