### PR TITLE
docs: change the install commands for Arch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We support two rendering backends, so first you need to set up one of these:
    <summary>Arch</summary>
 
    ```sh
-   sudo pacman -Syu ueberzugpp
+   sudo pacman -S ueberzugpp
    ```
 
    </details>
@@ -160,7 +160,7 @@ For `magick_rock` you need to install `luajitPackages.magick` as well ([thanks](
 <summary>Arch</summary>
 
 ```sh
-sudo pacman -Syu imagemagick
+sudo pacman -S imagemagick
 ```
 
 </details>


### PR DESCRIPTION
Changing the `pacman -Syu <package>` commands to `pacman -S <package>` since the original command would update all packages while also installing the target package

Using the new command would only install the package and not update the system.