### PR TITLE
fix: allow rendering image exactly at window bounds

### DIFF
--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -190,7 +190,7 @@ local render = function(image)
       -- that could be partially scrolled away.
       local diff = vim.fn.screenpos(image.window, win_info.topline, 0).row - win_info.winrow
 
-      if diff <= 0 then
+      if diff < 0 then
         return false -- out of bounds
       end
 
@@ -212,10 +212,10 @@ local render = function(image)
 
   -- clear out of bounds images
   if
-    absolute_y + height <= bounds.top
-    or absolute_y >= bounds.bottom + (vim.o.laststatus == 2 and 1 or 0)
-    or absolute_x + width <= bounds.left
-    or absolute_x >= bounds.right
+    absolute_y + height < bounds.top
+    or absolute_y > bounds.bottom + (vim.o.laststatus == 2 and 1 or 0)
+    or absolute_x + width < bounds.left
+    or absolute_x > bounds.right
   then
     if image.is_rendered then
       -- utils.debug("deleting out of bounds image", { id = image.id, x = absolute_x, y = absolute_y, width = width, height = height, bounds = bounds })


### PR DESCRIPTION
Hey,
I noticed that it's not possible to render image exactly at 0,0 with window=minimal on my neovim. I think the issue is that the bounds checking is too strict, leading to (x=0, y=0)  exiting early and returning false. Repro is below, please let me know if there's something wrong with it.

<details>
<summary>Versions (Ubuntu 22.04, nvim 0.12.0-dev), wezterm 20250604</summary>

```
$ nvim --version
NVIM v0.12.0-dev-197+g1dbede5b93
Build type: Release
LuaJIT 2.1.1744317938
Run "nvim -V1 -v" for more info
$ lsb_release -a
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.5 LTS
Release:        22.04
Codename:       jammy
$ wezterm --version
wezterm 20250604-060157-5106c8c1
```

</details>

<details>
<summary>Repro</summary>
Not a very minimal one, but works. Sourcing it without the patch does not draw the image. Sourcing it with the patch does. Without the patch, setting x,y to 1,1 fixes the issue, but paints the image with an offset.

```lua
# pick up the changes on re-source
for k, _ in pairs(package.loaded) do
  if vim.startswith(k, "image") and k ~= "image" then
    package.loaded[k] = nil
  end
end

local Image = require("image")
local ImageRenderer = {}

---@return ImageRenderer
function ImageRenderer:new(parentwin, parentbuf, opts)
  local buf = vim.api.nvim_create_buf(false, true)
  vim.api.nvim_buf_set_lines(buf, 0, 0, false, { "###", "###", "###", "###" })

  local obj = {
    parentbuf = parentbuf,
    parentwin = parentwin,
    height = opts.height or 10,
    width = opts.width or 20,
    bufpos = nil,
    win = nil,
    buf = buf,
    path = opts.path,
  }
  setmetatable(obj, { __index = self })
  return obj
end

function ImageRenderer:close()
  local win = self.win
  self.win = nil
  if win and vim.api.nvim_win_is_valid(win) then
    vim.schedule(function() pcall(vim.api.nvim_win_close, win, true) end)
  end
end

function ImageRenderer:render(pos)
  self:close()

  self.win = vim.api.nvim_open_win(self.buf, false, {
    bufpos = { pos[1], pos[2] },
    col = 0,
    focusable = true, -- FIXME
    height = self.height,
    noautocmd = true,
    relative = "win",
    row = 0,
    zindex = 11,
    style = "minimal",
    width = self.width,
    win = self.parentwin,
  })
  local image = assert(Image.from_file(self.path, {
    window = self.win,
    buffer = self.buf,
    inline = true,
  }))
  image:render({ x = 0, y = 0, width = self.width, height = self.height }) -- COORDS HERE

  local hl = "CurSearch" -- highlight to see window borders
  vim.api.nvim_set_option_value(
    "winhighlight",
    "TermCursorNC:" .. hl .. ",NormalFloat:" .. hl,
    { win = self.win }
  )
end

if _G.I ~= nil then
  _G.I:close()
end
_G.I = ImageRenderer:new(0, 0, { path = vim.fn.stdpath("config") .. "/wt.png" })
I:render({ 100, 20 })

return ImageRenderer
```

</details>
Running the above script, without changing the window spawns without an image. Changing the coordinates (at COORDS HERE) to 1,1 leads to the images below. I don't think there's a way to draw the image exactly at the border without these changes - please let me know if I'm wrong.

Before:
![image](https://github.com/user-attachments/assets/7dfff8cc-ccd8-43e4-8e89-5548cbb2643d)
After:
![image](https://github.com/user-attachments/assets/c70244f8-e574-48d2-badd-62d32c6bc902)
