### PR TITLE
fix: image incorrectly folded when rendered just under a fold

### DIFF
--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -104,7 +104,7 @@ local render = function(image)
     -- check if image is in fold
     local current_win = vim.api.nvim_get_current_win()
     vim.api.nvim_command("noautocmd call nvim_set_current_win(" .. image.window .. ")")
-    local is_folded = vim.fn.foldclosed(original_y) ~= -1
+    local is_folded = vim.fn.foldclosed(original_y + 1) ~= -1
     vim.api.nvim_command("noautocmd call nvim_set_current_win(" .. current_win .. ")")
 
     -- bail if it is


### PR DESCRIPTION
Noticed that images would get folded when rendered just under a fold. This seems to fix it since foldclosed is 1-based indexing but original_y is 0-based

Use case is I wanted to render a typst code block, embedded in markdown, with the block folded and the image placed right under the fold.
