### PR TITLE
feat: Improve remote image download error handling

### DIFF
--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -379,7 +379,7 @@ local from_url = function(url, options, callback, state)
     stdio = { nil, stdout, nil },
     hide = true,
   }, function(code, signal)
-    if code ~= 0 then
+    if (not state.options.ignore_download_error) and code ~= 0 then
       utils.throw("image: curl errored while downloading " .. url, {
         code = code,
         signal = signal,

--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -379,11 +379,18 @@ local from_url = function(url, options, callback, state)
     stdio = { nil, stdout, nil },
     hide = true,
   }, function(code, signal)
-    if (not state.options.ignore_download_error) and code ~= 0 then
-      utils.throw("image: curl errored while downloading " .. url, {
-        code = code,
-        signal = signal,
-      })
+    if code ~= 0 then
+      if state.options.ignore_download_error then
+        utils.debug("image: curl errored while downloading " .. url, {
+          code = code,
+          signal = signal,
+        })
+      else
+        utils.throw("image: curl errored while downloading " .. url, {
+          code = code,
+          signal = signal,
+        })
+      end
       callback(nil)
     end
   end)

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -37,6 +37,7 @@ local default_options = {
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "snacks_notif", "scrollview", "scrollview_sign" },
   editor_only_render_when_focused = false,
   tmux_show_only_in_active_window = false,
+  ignore_download_error = false,
   hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp", "*.avif" },
 }
 

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -48,6 +48,7 @@
 ---@field window_overlap_clear_ft_ignore? string[]
 ---@field editor_only_render_when_focused? boolean
 ---@field tmux_show_only_in_active_window? boolean
+---@field ignore_download_error? boolean
 ---@field hijack_file_patterns? string[]
 ---@field processor? string
 


### PR DESCRIPTION
This PR enhances how the plugin handles errors and warnings related to remote image downloads, offering users more control and better debugging capabilities. This is my first PR to this project, and I don't have a deep understanding of it yet. If there's any conflict with the project's roadmap, philosophy, or principles/guidelines, or if my code logic or style needs improvement, please don't hesitate to provide feedback.

### Description

Two main changes are introduced:

1.  **New `ignore_download_warning` option**: A new field has been added to the `Options` table to allow users to suppress warnings when a remote image download fails. This is useful for environments where download failures do not need to interrupt the user's workflow. (In my case, where ![noice.nvim](https://github.com/folke/noice.nvim) is installed, the warning message cover most of my screen when I was changing to normal mode and modifying the url.)

2.  **Debug Logging for Ignored Errors**: The "Download faied" message will be logged as a debug message instead of an explicit error when the `ignore_download_warning` option is enabled. Users can now inspect the logs to diagnose download problems without being shown an explicit error message, improving the debugging experience.

### Known Issue:
- When a remote image's URL is incorrect or inaccessible, the plugin will continuously try to download it as each `render` triggered, and generating a lot of debug messages. This problem is especially noticeable when the `only_render_image_at_cursor` option is enabled, as each cursor movement triggers a render.
    
### Future Work / Discussion

- To solve the above problem, a caching mechanism for "failed download URLs" could be considered. All URLs in the cache will not be
repeatedly tried for download, to avoid generating a lot of duplicate error messages.
- But this may also bring new problems: if the user is uploading pictures to the remote server, the caching mechanism may prevent the timely
display and update of the pictures.
- A possible solution is to add a TTL (Time To Live) mechanism to the cache, so that the "download failed" status is only valid for a certain period of time, and then retried after expiration.
- However, this will undoubtedly increase the complexity of the implementation. Whether this is a worthy trade-off is still open to
discussion 🤔.
