### PR TITLE
docs: update readme, add missing useful config option scale_factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ require("image").setup({
   max_height = nil,
   max_width_window_percentage = nil,
   max_height_window_percentage = 50,
+  scale_factor = 1.0,
   window_overlap_clear_enabled = false, -- toggles images when windows are overlapped
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "snacks_notif", "scrollview", "scrollview_sign" },
   editor_only_render_when_focused = false, -- auto show/hide images when the editor gains/looses focus


### PR DESCRIPTION
# Background

Allow controlling "zoom" level, to proportionally increase image size (#220)
feat: added scale_factor for custom global scaling (#252)