### PR TITLE
feat: add reStructuredText (rst) integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,9 @@ require("image").setup({
       enabled = true,
       filetypes = { "norg" },
     },
+    rst = {
+      enabled = true,
+    },
     typst = {
       enabled = true,
       filetypes = { "typst" },
@@ -431,6 +434,7 @@ All the backends support rendering inside Tmux.
 
 - `markdown` - uses [tree-sitter-markdown](https://github.com/MDeiml/tree-sitter-markdown) and supports any Markdown-based grammars (Quarto, VimWiki Markdown)
 - `neorg` - uses [tree-sitter-norg](https://github.com/nvim-neorg/tree-sitter-norg) (also check https://github.com/nvim-neorg/neorg/issues/971)
+- `rst` (reStructuredText) - uses [tree-sitter-rst](https://github.com/stsewd/tree-sitter-rst)
 - `typst` - thanks to @etiennecollin (https://github.com/3rd/image.nvim/pull/223)
 - `html` and `css` - thanks to @zuloo (https://github.com/3rd/image.nvim/pull/163)
 

--- a/lua/image/integrations/rst.lua
+++ b/lua/image/integrations/rst.lua
@@ -1,0 +1,61 @@
+local document = require("image/utils/document")
+
+return document.create_document_integration({
+  name = "rst",
+  debug = true,
+  default_options = {
+    clear_in_insert_mode = true,
+    download_remote_images = true,
+    only_render_image_at_cursor = false,
+    only_render_image_at_cursor_mode = "popup",
+    floating_windows = false,
+    filetypes = { "rst" },
+  },
+  query_buffer_images = function(buffer)
+    local buf = buffer or vim.api.nvim_get_current_buf()
+    local parser = vim.treesitter.get_parser(buf, "rst")
+    parser:parse(true)
+
+    local image_directive_query = vim.treesitter.query.parse("rst", [[
+      ((directive
+          name: (type) @_type
+          body: (body (arguments) @url)) @image
+       (#any-of? @_type "image" "figure"))
+    ]])
+
+    local images = {}
+
+    local function get_images(tree)
+      local root = tree:root()
+      local current_image = nil
+
+      for id, node in image_directive_query:iter_captures(root, buf) do
+        local key = image_directive_query.captures[id]
+        local value = vim.treesitter.get_node_text(node, buf)
+
+        if key == "image" then
+          local start_row, start_col, end_row, end_col = node:range()
+
+          current_image = {
+            node = node,
+            range = {
+              start_row = start_row,
+              start_col = start_col,
+              end_row = end_row,
+              end_col = end_col,
+            },
+          }
+
+        elseif current_image and key == "url" then
+          current_image.url = value
+          table.insert(images, current_image)
+          current_image = nil
+        end
+      end
+    end
+
+    parser:for_each_tree(get_images)
+
+    return images
+  end
+})


### PR DESCRIPTION
Tested on archlinux + kitty 0.44.0 + nvim 0.11.5 + image.nvim latest
<img width="604" height="610" alt="image" src="https://github.com/user-attachments/assets/30ace526-c4f5-4306-8b7f-ebd5a48b4359" />


In fact, I think integration of simple rST is not very useful. Most users use rST in the Sphinx documentation.

If possible, I will add support for Sphinx (more about the resolve_image_path stuff..)in the next PR.