### PR TITLE
feat: add Asciidoc integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,15 @@ require("image").setup({
       floating_windows = false, -- if true, images will be rendered in floating markdown windows
       filetypes = { "markdown", "vimwiki" }, -- markdown extensions (ie. quarto) can go here
     },
+    asciidoc = {
+      enabled = true,
+      clear_in_insert_mode = false,
+      download_remote_images = true,
+      only_render_image_at_cursor = false,
+      only_render_image_at_cursor_mode = "popup",
+      floating_windows = false,
+      filetypes = { "asciidoc", "adoc" },
+    },
     neorg = {
       enabled = true,
       filetypes = { "norg" },
@@ -430,6 +439,7 @@ All the backends support rendering inside Tmux.
 ### Integrations
 
 - `markdown` - uses [tree-sitter-markdown](https://github.com/MDeiml/tree-sitter-markdown) and supports any Markdown-based grammars (Quarto, VimWiki Markdown)
+- `asciidoc` - scans buffers for the [image macros](https://docs.asciidoctor.org/asciidoc/latest/macros/images/)
 - `neorg` - uses [tree-sitter-norg](https://github.com/nvim-neorg/tree-sitter-norg) (also check https://github.com/nvim-neorg/neorg/issues/971)
 - `typst` - thanks to @etiennecollin (https://github.com/3rd/image.nvim/pull/223)
 - `html` and `css` - thanks to @zuloo (https://github.com/3rd/image.nvim/pull/163)

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -19,6 +19,9 @@ local default_options = {
     markdown = {
       enabled = true,
     },
+    asciidoc = {
+      enabled = true,
+    },
     typst = {
       enabled = true,
     },
@@ -78,9 +81,7 @@ api.setup = function(options)
   state.options = opts
 
   -- setup logger with debug configuration
-  if opts.debug then
-    logger.setup(opts.debug)
-  end
+  if opts.debug then logger.setup(opts.debug) end
 
   vim.schedule(function()
     if opts.processor == "magick_rock" then

--- a/lua/image/integrations/asciidoc.lua
+++ b/lua/image/integrations/asciidoc.lua
@@ -1,0 +1,58 @@
+local document = require("image/utils/document")
+
+local function create_fake_ts_node(text, start_row, start_col, end_row, end_col)
+  local node = {}
+  node._text = text
+  node._range = { start_row, start_col, end_row, end_col }
+
+  function node:range()
+    return table.unpack(self._range)
+  end
+
+  function node:text()
+    return self._text
+  end
+
+  return node
+end
+
+return document.create_document_integration({
+  name = "asciidoc",
+  debug = true,
+  default_options = {
+    clear_in_insert_mode = false,
+    download_remote_images = true,
+    only_render_image_at_cursor = false,
+    only_render_image_at_cursor_mode = "popup",
+    floating_windows = false,
+    filetypes = { "asciidoc", "adoc" },
+  },
+
+  query_buffer_images = function(buffer)
+    local buf = buffer or vim.api.nvim_get_current_buf()
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local images = {}
+
+    local pattern = "image::?([^%[]+)%[(.-)%]"
+
+    for row, line in ipairs(lines) do
+      for url, alt in line:gmatch(pattern) do
+        local s, e = line:find("image:" .. url .. "[" .. alt .. "]", 1, true)
+        if not s then
+          s, e = line:find("image::" .. url .. "[" .. alt .. "]", 1, true)
+        end
+        if s and e then
+          local node = create_fake_ts_node(line:sub(s, e), row - 1, s - 1, row - 1, e - 1)
+          table.insert(images, {
+            node = node,
+            url = url,
+            alt = alt,
+            range = { start_row = row - 1, start_col = s - 1, end_row = row - 1, end_col = e - 1 },
+          })
+        end
+      end
+    end
+
+    return images
+  end,
+})


### PR DESCRIPTION
There is still no complete implementation of tree-sitter for Asciidoc. Maybe the most promissing attempt is that from [cathaysia/tree-sitter-asciidoc](https://github.com/cathaysia/tree-sitter-asciidoc).

Thus I'm simulating a TS node for the [images's macro of adoc](https://docs.asciidoctor.org/asciidoc/latest/macros/images/).

<img width="1300" height="974" alt="image" src="https://github.com/user-attachments/assets/f34888cd-c19c-49fc-a4d5-861c4b6b8704" />
