### PR TITLE
fix(term): handle terminal size query failure gracefully

### DIFF
--- a/lua/image/utils/term.lua
+++ b/lua/image/utils/term.lua
@@ -31,7 +31,7 @@ local update_size = function()
 
   ---@type { row: number, col: number, xpixel: number, ypixel: number }
   local sz = ffi.new("winsize")
-  assert(ffi.C.ioctl(1, TIOCGWINSZ, sz) == 0, "Failed to get terminal size")
+  if ffi.C.ioctl(1, TIOCGWINSZ, sz) ~= 0 then return end
 
   cached_size = {
     screen_x = sz.xpixel,


### PR DESCRIPTION
Replaces the assertion on ioctl failure with a silent return. This prevents crashes in environments where the terminal size cannot be queried, such as stated here https://github.com/3rd/image.nvim/issues/210#issuecomment-3303048924.

Making it fail silently so the plugin doesn't break the entire editor setup.