### PR TITLE
fix: add BufEnter to document integration autocmds

### DIFF
--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -234,7 +234,7 @@ local create_document_integration = function(config)
     local group = vim.api.nvim_create_augroup(group_name, { clear = true })
 
     -- watch for window changes
-    vim.api.nvim_create_autocmd({ "WinNew", "BufWinEnter", "TabEnter" }, {
+    vim.api.nvim_create_autocmd({ "WinNew", "BufWinEnter", "BufEnter", "TabEnter" }, {
       group = group,
       callback = function(args)
         if not has_valid_filetype(ctx, vim.bo[args.buf].filetype) then return end


### PR DESCRIPTION
## Summary
- Add `BufEnter` event to the document integration autocmd group in `lua/image/utils/document.lua`
- Without this, images don't render when revisiting an already-loaded buffer (e.g. opening from nvim-tree, `:bnext`/`:bprev`)
- `BufWinEnter` only fires the first time a buffer is displayed in a window; `BufEnter` fires every time

Fixes #347