### PR TITLE
feat: add overlap option and support negative render_offset_top

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,9 @@ local image = api.from_file("/path/to/image.png", {
   window = 1000, -- optional, binds image to a window and its bounds
   buffer = 1000, -- optional, binds image to a buffer (paired with window binding)
   with_virtual_padding = true, -- optional, pads vertically with extmarks, defaults to false
+  -- optional positive integer, number of existing buffer lines intentionally covered by the image.
+  -- Omit for normal virtual padding.
+  overlap = nil,
 
   -- optional, binds image to an extmark which it follows. Forced to be true when
   -- `with_virtual_padding` is true. defaults to false.

--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -108,9 +108,9 @@ function Image:render(geometry)
 
     -- create extmark
     if was_rendered then
-      -- subtract overlap lines to allow the rendered image to overlap with them
-      local total_height = math.max(0, height + (self.render_offset_top or 0) - (self.overlap or 0) + 1)
-      local has_up_to_date_extmark = previous_extmark and previous_extmark.height == total_height
+      -- reserve virtual lines for inline images, reduced only when overlap is explicitly set
+      local reserved_lines = utils.virtual_padding.get_reserved_lines(height, self.render_offset_top, self.overlap)
+      local has_up_to_date_extmark = previous_extmark and previous_extmark.height == reserved_lines
 
       if not has_up_to_date_extmark then
         if previous_extmark ~= nil then
@@ -122,8 +122,8 @@ function Image:render(geometry)
         local filler = {}
         local extmark_opts = { id = self.internal_id, strict = false }
         if self.with_virtual_padding then
-          local total_lines = math.max(0, height + (self.render_offset_top or 0) - (self.overlap or 0) + 1)
-          for _ = 0, total_lines - 1 do
+          -- only reserve the needed virtual height; actual rendering still happens in the renderer
+          for _ = 0, reserved_lines - 1 do
             filler[#filler + 1] = { { " ", "" } }
           end
           extmark_opts.virt_lines = filler
@@ -141,7 +141,7 @@ function Image:render(geometry)
           extmark_opts
         )
         if ok then
-          buf_extmark_map[extmark_key] = { id = self.internal_id, height = total_height or 0 }
+          buf_extmark_map[extmark_key] = { id = self.internal_id, height = reserved_lines }
           self.extmark = { id = extmark_id, row = extmark_row, col = extmark_col }
         end
       end
@@ -298,7 +298,7 @@ local from_file = function(path, options, state)
         inline = opts.inline or opts.with_virtual_padding or false,
         is_rendered = false,
         render_offset_top = opts.render_offset_top or 0,
-        overlap = opts.overlap or 0,
+        overlap = opts.overlap,
         crop_hash = nil,
         resize_hash = nil,
         namespace = opts.namespace or nil,
@@ -358,7 +358,7 @@ local from_file = function(path, options, state)
     inline = opts.inline or opts.with_virtual_padding or false,
     is_rendered = false,
     render_offset_top = opts.render_offset_top or 0,
-    overlap = opts.overlap or 0,
+    overlap = opts.overlap,
     crop_hash = nil,
     resize_hash = nil,
     namespace = opts.namespace or nil,

--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -108,7 +108,8 @@ function Image:render(geometry)
 
     -- create extmark
     if was_rendered then
-      local total_height = height + (self.render_offset_top or 0)
+      -- subtract overlap lines to allow the rendered image to overlap with them
+      local total_height = math.max(0, height + (self.render_offset_top or 0) - (self.overlap or 0) + 1)
       local has_up_to_date_extmark = previous_extmark and previous_extmark.height == total_height
 
       if not has_up_to_date_extmark then
@@ -121,8 +122,7 @@ function Image:render(geometry)
         local filler = {}
         local extmark_opts = { id = self.internal_id, strict = false }
         if self.with_virtual_padding then
-          -- only reserve real height for the extmark, padding is applied during rendering
-          local total_lines = height
+          local total_lines = math.max(0, height + (self.render_offset_top or 0) - (self.overlap or 0) + 1)
           for _ = 0, total_lines - 1 do
             filler[#filler + 1] = { { " ", "" } }
           end
@@ -298,6 +298,7 @@ local from_file = function(path, options, state)
         inline = opts.inline or opts.with_virtual_padding or false,
         is_rendered = false,
         render_offset_top = opts.render_offset_top or 0,
+        overlap = opts.overlap or 0,
         crop_hash = nil,
         resize_hash = nil,
         namespace = opts.namespace or nil,
@@ -357,6 +358,7 @@ local from_file = function(path, options, state)
     inline = opts.inline or opts.with_virtual_padding or false,
     is_rendered = false,
     render_offset_top = opts.render_offset_top or 0,
+    overlap = opts.overlap or 0,
     crop_hash = nil,
     resize_hash = nil,
     namespace = opts.namespace or nil,

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -194,11 +194,7 @@ local render = function(image)
   if image.window == nil then
     absolute_x = original_x
     absolute_y = original_y
-    -- apply render_offset_top
-    if image.render_offset_top and image.render_offset_top > 0 then
-      --
-      absolute_y = absolute_y + image.render_offset_top
-    end
+    absolute_y = absolute_y + (image.render_offset_top or 0)
   else
     -- get window object
     local window = nil
@@ -319,10 +315,10 @@ local render = function(image)
       absolute_x = screen_pos.col - 1
       absolute_y = screen_pos.row
     end
-    -- apply render_offset_top offset if set (but not for floating windows and not during partial scroll)
+    -- apply render_offset_top except for floating windows or during partial scroll
     local is_floating = window and window.is_floating or false
-    if image.render_offset_top and image.render_offset_top > 0 and not is_floating and not is_partial_scroll then
-      absolute_y = absolute_y + image.render_offset_top
+    if not is_floating and not is_partial_scroll then
+      absolute_y = absolute_y + (image.render_offset_top or 0)
     end
   end
 

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -247,69 +247,77 @@ local render = function(image)
         -- When image is on topline, we want normal rendering with padding
         is_partial_scroll = false
       else
-        -- Calculate the difference between the top line and top pos of window
-        -- Its the best way i found to calculate the possible extmark virt_lines
-        -- that could be partially scrolled away.
-        local topline_screen_pos = vim.fn.screenpos(image.window, win_info.topline, 0)
-        local diff = topline_screen_pos.row - win_info.winrow
+        local overlap_absolute_y = utils.virtual_padding.get_overlap_scroll_position(
+          original_y,
+          win_info.topline,
+          win_info.winrow,
+          height,
+          image.render_offset_top,
+          image.overlap
+        )
 
-        log.debug(("Image %s at/near topline calc"):format(image.id), {
-          original_y = original_y,
-          topline = win_info.topline,
-          topline_screen_row = topline_screen_pos.row,
-          winrow = win_info.winrow,
-          diff = diff,
-          height = height,
-        })
+        if overlap_absolute_y then
+          -- explicit overlap can keep the image visible by covering real buffer lines, not virt_lines.
+          is_partial_scroll = true
+          absolute_y = overlap_absolute_y
+          absolute_x = win_info.wincol - 1 + win_info.textoff + original_x
+        else
+          -- Calculate the difference between the top line and top pos of window
+          -- Its the best way i found to calculate the possible extmark virt_lines
+          -- that could be partially scrolled away.
+          local topline_screen_pos = vim.fn.screenpos(image.window, win_info.topline, 0)
+          local diff = topline_screen_pos.row - win_info.winrow
 
-        if diff <= 0 then
-          -- The topline is at a real buffer line (not in middle of virtual lines)
-          log.debug(("Image %s diff <= 0, cannot calculate position"):format(image.id))
-          if state.images[image.id] and state.images[image.id] ~= image then state.images[image.id]:clear(true) end
-          state.images[image.id] = image
-          return false -- cannot determine proper position
-        end
+          log.debug(("Image %s at/near topline calc"):format(image.id), {
+            original_y = original_y,
+            topline = win_info.topline,
+            topline_screen_row = topline_screen_pos.row,
+            winrow = win_info.winrow,
+            diff = diff,
+            height = height,
+          })
 
-        -- there is a diff which means that there are virt_lines that the user has
-        -- partially scrolled past
-
-        -- This calculation only makes sense if the image is at the line being scrolled (topline - 1)
-        -- If the image is further up, it shouldn't be visible at all
-        if original_y + 1 < win_info.topline - 1 then
-          log.debug(
-            ("Image %s is above the partially scrolled line (line %d < topline %d - 1), hiding"):format(
-              image.id,
-              original_y + 1,
-              win_info.topline
+          if diff <= 0 then
+            -- The topline is at a real buffer line, not in the middle of virtual lines.
+            log.debug(("Image %s diff <= 0, cannot calculate position"):format(image.id))
+            if state.images[image.id] and state.images[image.id] ~= image then state.images[image.id]:clear(true) end
+            state.images[image.id] = image
+            return false
+          elseif original_y + 1 < win_info.topline - 1 then
+            -- This calculation only makes sense if the image is at the line being scrolled (topline - 1).
+            -- If the image is further up, it should not be visible unless explicit overlap handled it above.
+            log.debug(
+              ("Image %s is above the partially scrolled line (line %d < topline %d - 1), hiding"):format(
+                image.id,
+                original_y + 1,
+                win_info.topline
+              )
             )
-          )
-          if state.images[image.id] and state.images[image.id] ~= image then state.images[image.id]:clear(true) end
-          state.images[image.id] = image
-          return false
+            if state.images[image.id] and state.images[image.id] ~= image then state.images[image.id]:clear(true) end
+            state.images[image.id] = image
+            return false
+          else
+            -- diff represents how many virtual rows are visible above the topline.
+            -- When diff = height, all virtual lines are visible and the image starts at winrow.
+            -- When diff = 1, only the bottom row is visible; the -1 accounts for 0-based math.
+            is_partial_scroll = true
+            absolute_y = win_info.winrow - height + diff - 1
+            -- screenpos is out of bounds here, so calculate x from the window origin and text offset.
+            absolute_x = win_info.wincol - 1 + win_info.textoff + original_x
+
+            log.debug(("Image %s calculated position for partial scroll"):format(image.id), {
+              absolute_x = absolute_x,
+              absolute_y = absolute_y,
+              calculation = string.format(
+                "winrow(%d) - height(%d) + diff(%d) - 1 = %d",
+                win_info.winrow,
+                height,
+                diff,
+                absolute_y
+              ),
+            })
+          end
         end
-
-        is_partial_scroll = true
-        -- diff represents how many rows of virtual content are visible above the topline
-        -- When diff = height, all virtual lines visible, image should start at winrow
-        -- When diff = 1, only bottom row visible
-        -- The -1 accounts for 0-based vs 1-based indexing
-        absolute_y = win_info.winrow - height + diff - 1
-        -- Try to manually calculate the x pos of the image.
-        -- We cant use the "built in" one since its out of bounds of the window
-        -- and therefore returns two 0s
-        absolute_x = win_info.wincol - 1 + win_info.textoff + original_x
-
-        log.debug(("Image %s calculated position for partial scroll"):format(image.id), {
-          absolute_x = absolute_x,
-          absolute_y = absolute_y,
-          calculation = string.format(
-            "winrow(%d) - height(%d) + diff(%d) - 1 = %d",
-            win_info.winrow,
-            height,
-            diff,
-            absolute_y
-          ),
-        })
       end
     else
       absolute_x = screen_pos.col - 1
@@ -317,9 +325,7 @@ local render = function(image)
     end
     -- apply render_offset_top except for floating windows or during partial scroll
     local is_floating = window and window.is_floating or false
-    if not is_floating and not is_partial_scroll then
-      absolute_y = absolute_y + (image.render_offset_top or 0)
-    end
+    if not is_floating and not is_partial_scroll then absolute_y = absolute_y + (image.render_offset_top or 0) end
   end
 
   -- clear out of bounds images

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -194,11 +194,7 @@ local render = function(image)
   if image.window == nil then
     absolute_x = original_x
     absolute_y = original_y
-    -- apply render_offset_top
-    if image.render_offset_top and image.render_offset_top > 0 then
-      --
-      absolute_y = absolute_y + image.render_offset_top
-    end
+    absolute_y = absolute_y + (image.render_offset_top or 0)
   else
     -- get window object
     local window = nil
@@ -317,10 +313,10 @@ local render = function(image)
       absolute_x = screen_pos.col - 1
       absolute_y = screen_pos.row
     end
-    -- apply render_offset_top offset if set (but not for floating windows and not during partial scroll)
+    -- apply render_offset_top except for floating windows or during partial scroll
     local is_floating = window and window.is_floating or false
-    if image.render_offset_top and image.render_offset_top > 0 and not is_floating and not is_partial_scroll then
-      absolute_y = absolute_y + image.render_offset_top
+    if not is_floating and not is_partial_scroll then
+      absolute_y = absolute_y + (image.render_offset_top or 0)
     end
   end
 

--- a/lua/image/utils/init.lua
+++ b/lua/image/utils/init.lua
@@ -8,6 +8,7 @@ local offsets = require("image/utils/offsets")
 local random = require("image/utils/random")
 local term = require("image/utils/term")
 local tmux = require("image/utils/tmux")
+local virtual_padding = require("image/utils/virtual_padding")
 local window = require("image/utils/window")
 
 return {
@@ -24,4 +25,5 @@ return {
   magic = magic,
   hash = hash,
   json = json,
+  virtual_padding = virtual_padding,
 }

--- a/lua/image/utils/virtual_padding.lua
+++ b/lua/image/utils/virtual_padding.lua
@@ -1,0 +1,58 @@
+local to_number = function(value, fallback)
+  if type(value) == "number" then return value end
+  return fallback
+end
+
+local get_positive_integer = function(value)
+  if type(value) ~= "number" then return nil end
+  if value <= 0 then return nil end
+  if value ~= math.floor(value) then return nil end
+  return value
+end
+
+---@param height number
+---@param render_offset_top? number
+---@param overlap? integer
+---@return number
+local get_reserved_lines = function(height, render_offset_top, overlap)
+  local image_height = math.max(0, to_number(height, 0))
+  local offset_top = to_number(render_offset_top, 0)
+  local overlap_lines = get_positive_integer(overlap)
+
+  -- nil or invalid overlap keeps normal virtual padding and still reserves render_offset_top rows.
+  if overlap_lines == nil then return math.max(0, image_height + offset_top) end
+
+  -- positive overlap counts real buffer lines covered by the image, including the anchor line.
+  return math.max(0, image_height + offset_top - overlap_lines + 1)
+end
+
+---@param original_y number
+---@param topline number
+---@param winrow number
+---@param height number
+---@param render_offset_top? number
+---@param overlap? integer
+---@return number? absolute_y
+---@return number? scrolled_lines
+local get_overlap_scroll_position = function(original_y, topline, winrow, height, render_offset_top, overlap)
+  local overlap_lines = get_positive_integer(overlap)
+  if overlap_lines == nil then return nil end
+
+  local anchor_line = original_y + 1
+  local scrolled_lines = topline - anchor_line
+  if scrolled_lines <= 0 then return nil end
+
+  -- overlap only helps while the viewport is still inside the real lines covered by the image.
+  if scrolled_lines >= overlap_lines then return nil end
+
+  local offset_top = to_number(render_offset_top, 0)
+  local visible_height = height + offset_top
+  if scrolled_lines >= visible_height then return nil end
+
+  return winrow + offset_top - scrolled_lines, scrolled_lines
+end
+
+return {
+  get_reserved_lines = get_reserved_lines,
+  get_overlap_scroll_position = get_overlap_scroll_position,
+}

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -87,6 +87,7 @@
 ---@field max_width_window_percentage? number
 ---@field max_height_window_percentage? number
 ---@field render_offset_top? number
+---@field overlap? integer
 
 ---@class ImageBounds
 ---@field top number
@@ -144,6 +145,7 @@
 ---@field has_extmark_moved fun (self:Image): (boolean, number?, number?)
 ---@field ignore_global_max_size? boolean
 ---@field render_offset_top? number
+---@field overlap? integer
 
 ---@class ImageProcessor
 --- We need to:

--- a/tests/core/lazy_loading_spec.lua
+++ b/tests/core/lazy_loading_spec.lua
@@ -129,13 +129,13 @@ describe("lazy loading", function()
 
   it("loads and sets up the backend on first backend use", function()
     local image = setup_image({
-      backend = "sixel",
+      backend = "kitty",
       processor = "magick_cli",
     })
 
-    assert.is_nil(package.loaded["image/backends/sixel"])
+    assert.is_nil(package.loaded["image/backends/kitty"])
     image.clear("missing")
-    assert.is_not_nil(package.loaded["image/backends/sixel"])
-    assert.is_not_nil(require("image/backends/sixel").state)
+    assert.is_not_nil(package.loaded["image/backends/kitty"])
+    assert.is_not_nil(require("image/backends/kitty").state)
   end)
 end)

--- a/tests/renderer/overlap_spec.lua
+++ b/tests/renderer/overlap_spec.lua
@@ -1,0 +1,166 @@
+local notify = vim.notify
+vim.notify = function() end
+
+local renderer = require("image/renderer")
+local utils = require("image/utils")
+
+vim.notify = notify
+
+describe("renderer overlap handling", function()
+  local originals
+
+  local make_image = function(opts)
+    local calls = {}
+    local window = vim.api.nvim_get_current_win()
+    local buffer = vim.api.nvim_get_current_buf()
+
+    local state = {
+      options = {
+        scale_factor = 1,
+        window_overlap_clear_enabled = false,
+        window_overlap_clear_ft_ignore = {},
+      },
+      images = {},
+      backend = {
+        features = { crop = true },
+        clear = function() end,
+        render = function(_, x, y, width, height)
+          calls[#calls + 1] = {
+            x = x,
+            y = y,
+            width = width,
+            height = height,
+          }
+        end,
+      },
+      processor = {},
+      tmp_dir = "/tmp",
+    }
+
+    local image = {
+      id = opts.id or "test-image",
+      path = "test.png",
+      original_path = "test.png",
+      image_width = 5,
+      image_height = 5,
+      window = window,
+      buffer = buffer,
+      global_state = state,
+      geometry = {
+        x = 2,
+        y = 4,
+        width = 5,
+        height = 5,
+      },
+      rendered_geometry = {},
+      render_offset_top = opts.render_offset_top,
+      overlap = opts.overlap,
+      is_rendered = false,
+    }
+
+    state.images[image.id] = image
+    return image, calls
+  end
+
+  local setup_window_mocks = function(opts)
+    local screenpos_calls = 0
+    local window = vim.api.nvim_get_current_win()
+    local buffer = vim.api.nvim_get_current_buf()
+
+    utils.term.get_size = function()
+      return {
+        cell_width = 1,
+        cell_height = 1,
+        screen_cols = 80,
+        screen_rows = 40,
+      }
+    end
+
+    utils.window.get_window = function()
+      return {
+        id = window,
+        buffer = buffer,
+        is_visible = true,
+        is_floating = false,
+        masks = {},
+        width = 80,
+        height = 40,
+        rect = {
+          top = 0,
+          right = 80,
+          bottom = 40,
+          left = 0,
+        },
+      }
+    end
+
+    vim.fn.getwininfo = function()
+      return {
+        {
+          botline = 20,
+          topline = opts.topline,
+          wincol = 1,
+          winrow = 10,
+          textoff = 3,
+        },
+      }
+    end
+
+    vim.fn.screenpos = function(_, line)
+      screenpos_calls = screenpos_calls + 1
+      if line == opts.topline then return { row = opts.topline_screen_row or 10, col = 1 } end
+      return { row = 0, col = 0 }
+    end
+
+    return function()
+      return screenpos_calls
+    end
+  end
+
+  before_each(function()
+    originals = {
+      get_size = utils.term.get_size,
+      get_window = utils.window.get_window,
+      getwininfo = vim.fn.getwininfo,
+      screenpos = vim.fn.screenpos,
+    }
+  end)
+
+  after_each(function()
+    utils.term.get_size = originals.get_size
+    utils.window.get_window = originals.get_window
+    vim.fn.getwininfo = originals.getwininfo
+    vim.fn.screenpos = originals.screenpos
+    renderer.clear_cache_for_path("test.png")
+  end)
+
+  it("keeps omitted overlap on the existing virtual-line fallback path", function()
+    local get_screenpos_calls = setup_window_mocks({
+      topline = 6,
+      topline_screen_row = 10,
+    })
+    local image, calls = make_image({
+      render_offset_top = 2,
+    })
+
+    assert.is_false(renderer.render(image))
+    assert.are.same(0, #calls)
+    assert.are.same(2, get_screenpos_calls())
+  end)
+
+  it("renders explicit overlap without applying render_offset_top twice", function()
+    local get_screenpos_calls = setup_window_mocks({
+      topline = 6,
+    })
+    local image, calls = make_image({
+      render_offset_top = 2,
+      overlap = 5,
+    })
+
+    assert.is_true(renderer.render(image))
+    assert.are.same(1, #calls)
+    assert.are.same(5, calls[1].x)
+    assert.are.same(11, calls[1].y)
+    assert.are.same(1, get_screenpos_calls())
+  end)
+end)

--- a/tests/utils/virtual_padding_spec.lua
+++ b/tests/utils/virtual_padding_spec.lua
@@ -1,0 +1,91 @@
+local virtual_padding = require("image/utils/virtual_padding")
+
+describe("virtual padding", function()
+  describe("get_reserved_lines", function()
+    it("uses normal virtual padding when overlap is omitted", function()
+      assert.are.same(5, virtual_padding.get_reserved_lines(5, 0, nil))
+    end)
+
+    it("reserves render offset when overlap is omitted", function()
+      assert.are.same(7, virtual_padding.get_reserved_lines(5, 2, nil))
+    end)
+
+    it("clamps omitted-overlap negative offset results at zero", function()
+      assert.are.same(0, virtual_padding.get_reserved_lines(2, -4, nil))
+    end)
+
+    it("uses normal virtual padding when overlap is zero", function()
+      assert.are.same(5, virtual_padding.get_reserved_lines(5, 0, 0))
+    end)
+
+    it("reserves render offset when overlap is zero", function()
+      assert.are.same(7, virtual_padding.get_reserved_lines(5, 2, 0))
+    end)
+
+    it("counts positive overlap from the anchor line", function()
+      assert.are.same(5, virtual_padding.get_reserved_lines(5, 0, 1))
+    end)
+
+    it("uses normal virtual padding when overlap is fractional", function()
+      assert.are.same(5, virtual_padding.get_reserved_lines(5, 0, 1.5))
+    end)
+
+    it("removes padding when overlap covers the rendered image", function()
+      assert.are.same(0, virtual_padding.get_reserved_lines(5, 0, 6))
+    end)
+
+    it("clamps negative offset results at zero", function()
+      assert.are.same(0, virtual_padding.get_reserved_lines(2, -4, 0))
+    end)
+  end)
+
+  describe("get_overlap_scroll_position", function()
+    it("does not handle omitted overlap", function()
+      assert.is_nil(virtual_padding.get_overlap_scroll_position(4, 6, 10, 5))
+    end)
+
+    it("does not handle zero overlap", function()
+      assert.is_nil(virtual_padding.get_overlap_scroll_position(4, 6, 10, 5, nil, 0))
+    end)
+
+    it("does not handle fractional overlap", function()
+      assert.is_nil(virtual_padding.get_overlap_scroll_position(4, 6, 10, 5, nil, 1.5))
+    end)
+
+    it("keeps explicit-overlap images visible while covered lines remain", function()
+      local absolute_y, scrolled_lines = virtual_padding.get_overlap_scroll_position(4, 6, 10, 5, 0, 5)
+
+      assert.are.same(9, absolute_y)
+      assert.are.same(1, scrolled_lines)
+    end)
+
+    it("keeps the last covered overlap line visible", function()
+      local absolute_y, scrolled_lines = virtual_padding.get_overlap_scroll_position(4, 9, 10, 5, 0, 5)
+
+      assert.are.same(6, absolute_y)
+      assert.are.same(4, scrolled_lines)
+    end)
+
+    it("uses render offset when calculating overlap scroll position", function()
+      local absolute_y, scrolled_lines = virtual_padding.get_overlap_scroll_position(4, 6, 10, 5, 2, 5)
+
+      assert.are.same(11, absolute_y)
+      assert.are.same(1, scrolled_lines)
+    end)
+
+    it("keeps the last visible image row visible", function()
+      local absolute_y, scrolled_lines = virtual_padding.get_overlap_scroll_position(4, 6, 10, 5, -3, 5)
+
+      assert.are.same(6, absolute_y)
+      assert.are.same(1, scrolled_lines)
+    end)
+
+    it("stops handling once scrolled beyond covered overlap lines", function()
+      assert.is_nil(virtual_padding.get_overlap_scroll_position(4, 10, 10, 5, nil, 5))
+    end)
+
+    it("stops handling once scrolled beyond visible image rows", function()
+      assert.is_nil(virtual_padding.get_overlap_scroll_position(4, 8, 10, 5, -3, 5))
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Add `overlap` option to `from_file()` — specifies how many buffer lines the image covers, reducing virtual padding accordingly
- Simplify `render_offset_top` handling to support negative values (allows shifting images upward)
- When `overlap` exceeds image height, no virtual padding is added (image fits within existing buffer lines)

Fixes #349