### PR TITLE
fix: include render_offset_top in virtual padding reservation

### DIFF
--- a/lua/image/image.lua
+++ b/lua/image/image.lua
@@ -121,8 +121,9 @@ function Image:render(geometry)
         local filler = {}
         local extmark_opts = { id = self.internal_id, strict = false }
         if self.with_virtual_padding then
-          -- only reserve real height for the extmark, padding is applied during rendering
-          local total_lines = height
+          -- reserve image height plus render_offset_top, since the offset
+          -- shifts the rendered image down without removing any of its rows
+          local total_lines = total_height
           for _ = 0, total_lines - 1 do
             filler[#filler + 1] = { { " ", "" } }
           end


### PR DESCRIPTION
Fixes #355.

## Summary

When `with_virtual_padding=true` and `render_offset_top > 0`, the rendered image is shifted down by `render_offset_top` cells (`renderer.lua:200`) but the extmark `virt_lines` reservation in `image.lua:125` only accounts for `height`. The last `render_offset_top` rows of the image therefore land on top of real buffer content immediately below the reserved area.

The `total_height` value (`height + render_offset_top`) is already computed three lines above for the cache-invalidation key, so it can be reused for the reservation itself.

## Diff

```diff
 if self.with_virtual_padding then
-  -- only reserve real height for the extmark, padding is applied during rendering
-  local total_lines = height
+  -- reserve image height plus render_offset_top, since the offset
+  -- shifts the rendered image down without removing any of its rows
+  local total_lines = total_height
   for _ = 0, total_lines - 1 do
     filler[#filler + 1] = { { " ", "" } }
   end
   extmark_opts.virt_lines = filler
 end
```

## Test plan

The repro from #355 now shows the marker line uncovered. Verified visually in Ghostty against `diagram.nvim`'s mermaid integration (which always sets `render_offset_top = 1`).

No new automated tests — the existing test suite has no coverage for `Image:render`'s extmark layout, and adding one here would require mocking the renderer / buffer state, which felt out of scope for a 1-line fix. Happy to add one if you'd prefer.