### PR TITLE
fix: large Kitty direct image transfers over SSH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ require("image").setup({
   max_width_window_percentage = nil,
   max_height_window_percentage = 50,
   scale_factor = 1.0,
+  kitty_direct_chunk_size = 4096, -- chunk size for direct Kitty graphics protocol transmission
   window_overlap_clear_enabled = false, -- toggles images when windows are overlapped
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "snacks_notif", "scrollview", "scrollview_sign" },
   editor_only_render_when_focused = false, -- auto show/hide images when the editor gains/looses focus

--- a/lua/image/backends/kitty/helpers.lua
+++ b/lua/image/backends/kitty/helpers.lua
@@ -12,12 +12,17 @@ if not stdout then error("failed to open stdout") end
 local is_SSH = (vim.env.SSH_CLIENT ~= nil) or (vim.env.SSH_TTY ~= nil)
 
 -- https://github.com/edluffy/hologram.nvim/blob/main/lua/hologram/terminal.lua#L77
-local DIRECT_CHUNK_SIZE = 65536
+local DEFAULT_DIRECT_CHUNK_SIZE = 4096
 
-local get_chunked = function(str)
+local get_chunk_size = function(chunk_size)
+  return type(chunk_size) == "number" and chunk_size > 0 and chunk_size or DEFAULT_DIRECT_CHUNK_SIZE
+end
+
+local get_chunked = function(str, chunk_size)
+  chunk_size = get_chunk_size(chunk_size)
   local chunks = {}
-  for i = 1, #str, DIRECT_CHUNK_SIZE do
-    local chunk = str:sub(i, i + DIRECT_CHUNK_SIZE - 1):gsub("%s", "")
+  for i = 1, #str, chunk_size do
+    local chunk = str:sub(i, i + chunk_size - 1):gsub("%s", "")
     table.insert(chunks, chunk)
   end
   return chunks
@@ -96,8 +101,9 @@ end
 
 ---@param config KittyControlConfig
 ---@param data? string
+---@param direct_chunk_size? number
 -- https://github.com/edluffy/hologram.nvim/blob/main/lua/hologram/terminal.lua#L52
-local write_graphics = function(config, data)
+local write_graphics = function(config, data, direct_chunk_size)
   log.debug("write_graphics", { config = config, has_data = data ~= nil })
 
   local control_payload = build_control_payload(config)
@@ -119,7 +125,7 @@ local write_graphics = function(config, data)
       data = result
     end
     data = vim.base64.encode(data):gsub("%-", "/")
-    local chunks = get_chunked(data)
+    local chunks = get_chunked(data, direct_chunk_size)
     local m = #chunks > 1 and 1 or 0
     control_payload = control_payload .. ",m=" .. m
     for i = 1, #chunks do

--- a/lua/image/backends/kitty/helpers.lua
+++ b/lua/image/backends/kitty/helpers.lua
@@ -12,11 +12,13 @@ if not stdout then error("failed to open stdout") end
 local is_SSH = (vim.env.SSH_CLIENT ~= nil) or (vim.env.SSH_TTY ~= nil)
 
 -- https://github.com/edluffy/hologram.nvim/blob/main/lua/hologram/terminal.lua#L77
+local DIRECT_CHUNK_SIZE = 65536
+
 local get_chunked = function(str)
   local chunks = {}
-  for i = 1, #str, 4096 do
-    local chunk = str:sub(i, i + 4096 - 1):gsub("%s", "")
-    if #chunk > 0 then table.insert(chunks, chunk) end
+  for i = 1, #str, DIRECT_CHUNK_SIZE do
+    local chunk = str:sub(i, i + DIRECT_CHUNK_SIZE - 1):gsub("%s", "")
+    table.insert(chunks, chunk)
   end
   return chunks
 end

--- a/lua/image/backends/kitty/init.lua
+++ b/lua/image/backends/kitty/init.lua
@@ -26,6 +26,7 @@ vim.api.nvim_create_autocmd("VimResized", {
 
 backend.setup = function(state)
   backend.state = state
+
   if utils.tmux.is_tmux and not utils.tmux.has_passthrough then
     utils.throw("tmux does not have allow-passthrough enabled")
     return
@@ -59,7 +60,7 @@ backend.render = function(image, x, y, width, height)
       quiet = 2,
     }
     if with_virtual_placeholders then transmit_payload.display_virtual_placeholder = 1 end
-    helpers.write_graphics(transmit_payload, image.cropped_path)
+    helpers.write_graphics(transmit_payload, image.cropped_path, backend.state.options.kitty_direct_chunk_size)
     log.debug("transmitted image " .. image.id .. " (" .. image.internal_id .. ")")
   end
   if backend.features.crop then

--- a/lua/image/backends/kitty/init.lua
+++ b/lua/image/backends/kitty/init.lua
@@ -54,6 +54,7 @@ backend.render = function(image, x, y, width, height)
       image_id = image.internal_id,
       transmit_format = codes.control.transmit_format.png,
       transmit_medium = transmit_medium,
+      tty = transmit_medium == codes.control.transmit_medium.direct and editor_tty or nil,
       display_cursor_policy = codes.control.display_cursor_policy.do_not_move,
       quiet = 2,
     }

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -55,6 +55,7 @@ local default_options = {
   max_height_window_percentage = 50,
   scale_factor = 1.0,
   kitty_method = "normal",
+  kitty_direct_chunk_size = 4096,
   window_overlap_clear_enabled = false,
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "snacks_notif", "scrollview", "scrollview_sign" },
   editor_only_render_when_focused = false,

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -50,6 +50,7 @@
 ---@field max_height_window_percentage? number
 ---@field scale_factor? number
 ---@field kitty_method "normal"|"unicode-placeholders"
+---@field kitty_direct_chunk_size? number
 ---@field window_overlap_clear_enabled? boolean
 ---@field window_overlap_clear_ft_ignore? string[]
 ---@field editor_only_render_when_focused? boolean


### PR DESCRIPTION
First of all this fixes #95 #294 . When running over SSH, the Kitty backend uses direct transfer mode. Large images are split into many base64 chunks and written to the terminal stream. Without passing `editor_tty`, those chunks go through Neovim's stdout path, where Neovim redraw/control bytes can interleave with the Kitty graphics payload. This corrupts the base64 stream.

I confirmed this with `kitty --dump-bytes`: failed large transfers contained Neovim escape sequences inside the image payload. Passing `editor_tty` makes the existing tty write path handle direct transfers and prevents that corruption.

This also increases the direct transfer chunk size from 4096 to 65536 bytes. In my test case, this reduced a large image transfer from 1223 Kitty graphics commands to 77 while preserving a valid decoded payload.

To create the dump:
```bash
kitty --dump-bytes /tmp/kitty.bytes --dump-commands sh -lc 'ssh faepmac1'
```
then create a large image:
```bash
magick -size 1600x1000 plasma:fractal /tmp/image-large.png
```
then open a large image with Neovim


To analyze the dump:
```python
#!/usr/bin/env python3
import base64
import hashlib
import re
import sys
from pathlib import Path

dump_path = Path(sys.argv[1])
candidate_root = Path(sys.argv[2]) if len(sys.argv) > 2 else None

b = dump_path.read_bytes()

seqs = re.findall(rb"\x1b_G(.*?)\x1b\\", b, flags=re.S)

print(f"dump bytes: {len(b)}")
print(f"kitty graphics sequences: {len(seqs)}")

unescaped_g = 0
for m in re.finditer(rb"_G", b):
    i = m.start()
    if i == 0 or b[i - 1] != 0x1B:
        unescaped_g += 1

print(f"unescaped literal _G occurrences: {unescaped_g}")

transfers = []
current = None

for seq in seqs:
    if b";" not in seq:
        continue

    header, payload = seq.split(b";", 1)
    if not payload:
        continue

    # Parse simple k=v header fields.
    params = {}
    for part in header.split(b","):
        if b"=" in part:
            k, v = part.split(b"=", 1)
            params[k] = v

    # First chunk has a full header; continuation chunks are usually just m=1/m=0.
    is_continuation = set(params.keys()).issubset({b"m"})

    if current is None or not is_continuation:
        current = {
            "first_header": header,
            "chunks": [],
        }

    current["chunks"].append(payload)

    if params.get(b"m") == b"0":
        transfers.append(current)
        current = None

if current is not None:
    transfers.append(current)

print(f"data transfers found: {len(transfers)}")

candidate_hashes = {}
if candidate_root and candidate_root.exists():
    for path in candidate_root.rglob("*.png"):
        try:
            data = path.read_bytes()
        except Exception:
            continue
        candidate_hashes[hashlib.sha256(data).hexdigest()] = path

for idx, tr in enumerate(transfers, 1):
    joined = b"".join(tr["chunks"])
    padded = joined + b"=" * ((4 - len(joined) % 4) % 4)

    print()
    print(f"transfer #{idx}")
    print(f"  first header: {tr['first_header'][:200].decode('ascii', 'replace')}")
    print(f"  chunks: {len(tr['chunks'])}")
    print(f"  b64 bytes: {len(joined)}")

    try:
        raw = base64.b64decode(padded, validate=True)
    except Exception as e:
        print(f"  base64 decode: FAILED: {e}")
        continue

    sha = hashlib.sha256(raw).hexdigest()
    print(f"  decoded bytes: {len(raw)}")
    print(f"  sha256: {sha}")

    out = Path(f"/tmp/reconstructed-kitty-transfer-{idx}.png")
    out.write_bytes(raw)
    print(f"  wrote: {out}")

    if sha in candidate_hashes:
        print(f"  matches candidate: {candidate_hashes[sha]}")
    else:
        print("  matches candidate: no")
```

Test with ssh and ssh+tmux and just tmux.