### PR TITLE
fix(sixel): wrap dcs sequence for tmux fowarding

### DIFF
--- a/lua/image/backends/sixel.lua
+++ b/lua/image/backends/sixel.lua
@@ -128,6 +128,11 @@ local send_sixel = function(sixel_data, x, y)
   if not has_dcs_start then wrapped_data = "\27P0;1;0q" .. wrapped_data end
   if not has_st_end then wrapped_data = wrapped_data .. "\27\\" end
 
+  -- tmux passthrough: wrap DCS sequence so tmux forwards it to the terminal
+  if utils.tmux.is_tmux then
+    wrapped_data = utils.tmux.escape(wrapped_data)
+  end
+
   -- build sequence
   local sequence = ""
 


### PR DESCRIPTION
# Problem

In tmux, sixel images display as raw text characters (e.g. `SIXEL +++++`) instead of rendering
the image. Outside tmux, sixel works fine.

# Fix

Reuse the existing `utils.tmux.escape()` helper (already used by the kitty backend), which
wraps the DCS sequence using tmux's standard passthrough protocol.

https://github.com/3rd/image.nvim/blob/44e07129cd0ea0c60afa7a1991d35b5765b51a6b/lua/image/backends/kitty/helpers.lua#L38

## Before

<details>

<img width="388" height="402" alt="image" src="https://github.com/user-attachments/assets/051190bb-6e7e-4787-a5c4-2f3697ba0d4a" />

</details>

## After

<details>

<img width="603" height="822" alt="image" src="https://github.com/user-attachments/assets/62219755-1205-44bb-a71a-d227a88cbc42" />

</details>
