### PR TITLE
feat(core): make popup respect config sizes

### DIFF
--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -45,6 +45,9 @@ local render = function(image)
   if type(state.options.scale_factor) == "number" then scale_factor = state.options.scale_factor end
   local natural_image_rows = math.floor(image.image_height / term_size.cell_height)
   local natural_image_columns = math.floor(image.image_width / term_size.cell_width)
+  -- scaled natural size: the image must never be rendered larger than this
+  local scaled_natural_width = math.max(1, math.floor(natural_image_columns * scale_factor))
+  local scaled_natural_height = math.max(1, math.floor(natural_image_rows * scale_factor))
 
   log.debug(("render() %s"):format(image.id), {
     id = image.id,
@@ -72,23 +75,19 @@ local render = function(image)
   if width == 0 and height ~= 0 then width = math.ceil(geometry_height_px * aspect_ratio / term_size.cell_width) end
   if height == 0 and width ~= 0 then height = math.ceil(geometry_width_px / aspect_ratio / term_size.cell_height) end
 
-  -- if both w/h are missing, use the natural image dimensions (unscaled)
+  -- if both w/h are missing, use the scaled natural image dimensions
   if width == 0 and height == 0 then
-    width = natural_image_columns
-    height = natural_image_rows
+    width = scaled_natural_width
+    height = scaled_natural_height
   end
 
   -- rendered size cannot be larger than the image itself
-  -- width = math.min(width, natural_image_columns)
-  -- height = math.min(height, natural_image_rows)
+  width = math.min(width, scaled_natural_width)
+  height = math.min(height, scaled_natural_height)
 
   -- screen max width/height
   width = math.min(width, term_size.screen_cols)
   -- height = math.min(height, term_size.screen_rows)
-
-  -- apply scale_factor to resolved geometry
-  width = math.max(1, math.floor(width * scale_factor))
-  height = math.max(1, math.floor(height * scale_factor))
 
   log.debug(("(1) x: %d, y: %d, width: %d, height: %d"):format(original_x, original_y, width, height))
 

--- a/lua/image/renderer.lua
+++ b/lua/image/renderer.lua
@@ -43,8 +43,8 @@ local render = function(image)
   if not term_size then return end
   local scale_factor = 1.0
   if type(state.options.scale_factor) == "number" then scale_factor = state.options.scale_factor end
-  local image_rows = math.floor(image.image_height / term_size.cell_height * scale_factor)
-  local image_columns = math.floor(image.image_width / term_size.cell_width * scale_factor)
+  local natural_image_rows = math.floor(image.image_height / term_size.cell_height)
+  local natural_image_columns = math.floor(image.image_width / term_size.cell_width)
 
   log.debug(("render() %s"):format(image.id), {
     id = image.id,
@@ -72,19 +72,23 @@ local render = function(image)
   if width == 0 and height ~= 0 then width = math.ceil(geometry_height_px * aspect_ratio / term_size.cell_width) end
   if height == 0 and width ~= 0 then height = math.ceil(geometry_width_px / aspect_ratio / term_size.cell_height) end
 
-  -- if both w/h are missing, use the image dimensions
+  -- if both w/h are missing, use the natural image dimensions (unscaled)
   if width == 0 and height == 0 then
-    width = image_columns
-    height = image_rows
+    width = natural_image_columns
+    height = natural_image_rows
   end
 
   -- rendered size cannot be larger than the image itself
-  -- width = math.min(width, image_columns)
-  -- height = math.min(height, image_rows)
+  -- width = math.min(width, natural_image_columns)
+  -- height = math.min(height, natural_image_rows)
 
   -- screen max width/height
   width = math.min(width, term_size.screen_cols)
   -- height = math.min(height, term_size.screen_rows)
+
+  -- apply scale_factor to resolved geometry
+  width = math.max(1, math.floor(width * scale_factor))
+  height = math.max(1, math.floor(height * scale_factor))
 
   log.debug(("(1) x: %d, y: %d, width: %d, height: %d"):format(original_x, original_y, width, height))
 

--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -162,7 +162,6 @@ local create_document_integration = function(config)
     local win = vim.api.nvim_open_win(buf, false, win_config)
     popup_window = win
 
-    image.ignore_global_max_size = true
     image.window = win
     image.buffer = buf
 

--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -141,12 +141,34 @@ local create_document_integration = function(config)
 
     local term_size = utils.term.get_size()
     if not term_size then return end
-    local width, height = utils.math.adjust_to_aspect_ratio(
+    local state = image.global_state
+    local scale_factor = state.options.scale_factor or 1.0
+
+    -- compute the image's scaled natural width and apply same constraints as the renderer
+    local natural_width = math.max(1, math.floor(image.image_width / term_size.cell_width * scale_factor))
+    local width = math.min(natural_width, math.floor(term_size.screen_cols / 2))
+    if state.options.max_width then width = math.min(width, state.options.max_width) end
+    if state.options.max_width_window_percentage then
+      width = math.min(width, math.floor(term_size.screen_cols * state.options.max_width_window_percentage / 100))
+    end
+    local height = 0
+    width, height = utils.math.adjust_to_aspect_ratio(
       term_size,
       image.image_width,
       image.image_height,
-      math.floor(term_size.screen_cols / 2),
-      0
+      width,
+      height
+    )
+    if state.options.max_height then height = math.min(height, state.options.max_height) end
+    if state.options.max_height_window_percentage then
+      height = math.min(height, math.floor(term_size.screen_rows * state.options.max_height_window_percentage / 100))
+    end
+    width, height = utils.math.adjust_to_aspect_ratio(
+      term_size,
+      image.image_width,
+      image.image_height,
+      width,
+      height
     )
     local win_config = {
       relative = "cursor",
@@ -162,6 +184,7 @@ local create_document_integration = function(config)
     local win = vim.api.nvim_open_win(buf, false, win_config)
     popup_window = win
 
+    image.ignore_global_max_size = true
     image.window = win
     image.buffer = buf
 


### PR DESCRIPTION
# Problem

scale_factor, max_width, max_height, max_width_window_percentage, and max_height_window_percentage were all silently ignored for markdown images rendered in popup mode (only_render_image_at_cursor_mode = "popup").

# Fix

- renderer.lua
  - Cap ALL geometry to the image's scaled natural size
- document.lua
  - Popup window pre-computes final image size
 
Instead of always using screen_cols / 2 as the popup width, the popup now:

 1. Computes the scaled natural width (image_width / cell_width × scale_factor)
 2. Caps at half screen
 3. Applies max_width, max_width_window_percentage (vs screen)
 4. Derives height from aspect ratio, applies max_height, max_height_window_percentage
 5. Re-adjusts aspect ratio if height was constrained

## Before

<details>

<img width="1239" height="1245" alt="image" src="https://github.com/user-attachments/assets/e2e2e3db-b199-461b-a860-0cdca53d9a51" />

</details>

## After

<details>

<img width="441" height="584" alt="image" src="https://github.com/user-attachments/assets/bc2dc7bd-7ba5-4e74-a305-f00a2a46468f" />

</details>