### PR TITLE
feat: expose option to configure the popup border in plugin opts

### DIFF
--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -53,6 +53,7 @@ local default_options = {
   max_height = nil,
   max_width_window_percentage = 100,
   max_height_window_percentage = 50,
+  popup_border = "single",
   scale_factor = 1.0,
   kitty_method = "normal",
   kitty_direct_chunk_size = 4096,

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -12,6 +12,12 @@ local backend_modules = {
   sixel = "image/backends/sixel",
 }
 
+---@return string
+local winborder_or_fallback = function()
+  if vim.o.winborder == "" then return "single" end
+  return vim.o.winborder
+end
+
 ---@type Options
 local default_options = {
   -- backend = "ueberzug",
@@ -53,7 +59,7 @@ local default_options = {
   max_height = nil,
   max_width_window_percentage = 100,
   max_height_window_percentage = 50,
-  popup_border = "single",
+  popup_border = winborder_or_fallback(),
   scale_factor = 1.0,
   kitty_method = "normal",
   kitty_direct_chunk_size = 4096,

--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -136,7 +136,7 @@ local create_document_integration = function(config)
     return should_render_match(ctx, window, item.match, cursor_row)
   end
 
-  local render_popup_image = function(image)
+  local render_popup_image = function(image, popup_border)
     if popup_window ~= nil then return end
 
     local term_size = utils.term.get_size()
@@ -155,7 +155,7 @@ local create_document_integration = function(config)
       width = width,
       height = height,
       style = "minimal",
-      border = "single",
+      border = popup_border,
     }
     local buf = vim.api.nvim_create_buf(false, true)
     vim.bo[buf].filetype = "image_nvim_popup"
@@ -192,7 +192,8 @@ local create_document_integration = function(config)
   local render_image = function(ctx, item, image)
     log.debug("render_image called", { id = image.id })
     if ctx.options.only_render_image_at_cursor and ctx.options.only_render_image_at_cursor_mode == "popup" then
-      render_popup_image(image)
+      local popup_border = ctx.state.options.popup_border or "single"
+      render_popup_image(image, popup_border)
       return
     end
 

--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -192,8 +192,7 @@ local create_document_integration = function(config)
   local render_image = function(ctx, item, image)
     log.debug("render_image called", { id = image.id })
     if ctx.options.only_render_image_at_cursor and ctx.options.only_render_image_at_cursor_mode == "popup" then
-      local popup_border = ctx.state.options.popup_border or "single"
-      render_popup_image(image, popup_border)
+      render_popup_image(image, ctx.state.options.popup_border)
       return
     end
 


### PR DESCRIPTION
I added an option to configure the popup border as needed this for style consistency. Quick tweak. Could be improved maybe by getting it to respect global "winborder" but that's a task for tomorrow me. 

For example configure:
```lua
-- ...
		max_width = nil,
		max_height = nil,
		max_width_window_percentage = 40,
		max_height_window_percentage = 35,
		popup_border = "rounded",
		scale_factor = 1.0,
--...
```

to get this: (here working with version patched with [#367](https://github.com/3rd/image.nvim/pull/367) )
<img width="652" height="568" alt="image" src="https://github.com/user-attachments/assets/033d0326-89b7-42f5-9cec-1dd5682befcc" />
