### PR TITLE
feat(tmux): add tmux_passthrough_layers for nested tmux (local + remote over SSH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ require("image").setup({
   max_height_window_percentage = 50,
   scale_factor = 1.0,
   kitty_direct_chunk_size = 4096, -- chunk size for direct Kitty graphics protocol transmission
+  tmux_passthrough_layers = 1, -- number of tmux layers to wrap the passthrough escape for; set to 2 for a local tmux + a remote tmux over SSH
   window_overlap_clear_enabled = false, -- toggles images when windows are overlapped
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "snacks_notif", "scrollview", "scrollview_sign" },
   editor_only_render_when_focused = false, -- auto show/hide images when the editor gains/looses focus

--- a/lua/image/init.lua
+++ b/lua/image/init.lua
@@ -56,6 +56,9 @@ local default_options = {
   scale_factor = 1.0,
   kitty_method = "normal",
   kitty_direct_chunk_size = 4096,
+  -- Number of nested tmux layers between nvim and the terminal (each strips one
+  -- passthrough envelope). Bump to 2 for a local tmux + a remote tmux over SSH.
+  tmux_passthrough_layers = 1,
   window_overlap_clear_enabled = false,
   window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "snacks_notif", "scrollview", "scrollview_sign" },
   editor_only_render_when_focused = false,
@@ -114,6 +117,7 @@ end
 api.setup = function(options)
   local opts = vim.tbl_deep_extend("force", default_options, options or {})
   state.options = opts
+  utils.tmux.set_passthrough_layers(opts.tmux_passthrough_layers)
 
   -- setup logger with debug configuration
   if opts.debug then logger.setup(opts.debug) end

--- a/lua/image/utils/tmux.lua
+++ b/lua/image/utils/tmux.lua
@@ -80,8 +80,22 @@ local create_dm_pane_getter = function(name)
   end
 end
 
+-- Number of tmux passthrough envelopes to wrap graphics escapes in. Each tmux the
+-- output crosses strips exactly one envelope, so nested tmux (e.g. a local tmux plus a
+-- remote tmux over SSH) needs one envelope PER layer, otherwise the outer tmux drops the
+-- escape and kitty shows placeholder glyphs instead of the image. Set via the
+-- `tmux_passthrough_layers` option (default 1).
+local passthrough_layers = 1
+
+local set_passthrough_layers = function(n)
+  if type(n) == "number" and n >= 1 then passthrough_layers = math.floor(n) end
+end
+
 local escape = function(sequence)
-  return "\x1bPtmux;" .. sequence:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
+  for _ = 1, passthrough_layers do
+    sequence = "\x1bPtmux;" .. sequence:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
+  end
+  return sequence
 end
 
 local get_version = function()
@@ -107,4 +121,5 @@ return {
   get_cursor_y = create_dm_getter("cursor_y"),
   get_version = get_version,
   escape = escape,
+  set_passthrough_layers = set_passthrough_layers,
 }

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -55,6 +55,7 @@
 ---@field window_overlap_clear_ft_ignore? string[]
 ---@field editor_only_render_when_focused? boolean
 ---@field tmux_show_only_in_active_window? boolean
+---@field tmux_passthrough_layers? integer
 ---@field ignore_download_error? boolean
 ---@field hijack_file_patterns? string[]
 ---@field processor? string


### PR DESCRIPTION
## Problem

tmux only forwards a terminal-graphics escape when it's wrapped in the passthrough envelope (`\ePtmux;…\e\\`), and **each tmux layer strips exactly one envelope**. In a **nested tmux** setup — a local tmux plus a remote tmux reached over SSH — the graphics escape has to be wrapped **once per layer**.

Today `tmux.escape` wraps only **once** (it can only see one `$TMUX`). So the inner (remote) tmux unwraps it and emits a *raw* graphics escape, which the outer (local) tmux then drops — kitty renders Unicode **placeholder glyphs** instead of the image, even with `allow-passthrough on` on both tmux. Text/TUI is unaffected; only pixels fail. `kitten icat` has the same single-wrap limitation, so this hits the very common "SSH from a local tmux into a remote tmux" workflow.

```mermaid
graph LR
  N["nvim (wrap x1)"] --> S["remote tmux"]
  S -->|"unwrap -> RAW"| L["local tmux"]
  L -->|"dropped"| K["kitty: no image"]
  N2["nvim (layers=2)"] --> S2["remote tmux"]
  S2 -->|"unwrap -> wrap x1"| L2["local tmux"]
  L2 -->|"unwrap -> raw"| K2["kitty: image!"]
```

## Fix

Add a `tmux_passthrough_layers` option (default **1**, existing behavior unchanged) that wraps the envelope N times:

```lua
require("image").setup({
  backend = "kitty",
  tmux_passthrough_layers = 2, -- local tmux + remote tmux over SSH
})
```

There's no reliable way to auto-detect this — a server-side nvim can't see the client-side tmux (`$TMUX` shows only the remote one) — so it's an explicit opt-in.

## Changes
- `lua/image/utils/tmux.lua`: `escape` wraps `passthrough_layers` times; add `set_passthrough_layers`.
- `lua/image/init.lua`: `tmux_passthrough_layers = 1` default, applied in `setup`.
- `lua/types.lua`, `README.md`: document the option.

## Testing
- `escape("X")` → 10 bytes at default (x1), 21 bytes at `layers=2` (inner ESCs doubled) — verified.
- Confirmed end-to-end on a real `kitty → local tmux → ssh → remote tmux → nvim` stack: diagram/mermaid images that previously showed only placeholder glyphs now render with `tmux_passthrough_layers = 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
