### PR TITLE
fix(document): cap popup size at the image's natural size

### DIFF
--- a/lua/image/utils/document.lua
+++ b/lua/image/utils/document.lua
@@ -141,13 +141,21 @@ local create_document_integration = function(config)
 
     local term_size = utils.term.get_size()
     if not term_size then return end
+
+    -- Cap at the image's natural width, not an unconditional screen_cols/2 --
+    -- otherwise a 78x20 badge also gets a half-screen window.
+    local natural_cols = math.ceil(image.image_width / term_size.cell_width)
+    local requested_cols = math.min(natural_cols, math.floor(term_size.screen_cols / 2))
     local width, height = utils.math.adjust_to_aspect_ratio(
       term_size,
       image.image_width,
       image.image_height,
-      math.floor(term_size.screen_cols / 2),
+      math.max(1, requested_cols),
       0
     )
+
+    -- Aspect-ratio fitting can still overshoot vertically on a tall image.
+    height = math.min(height, math.max(1, term_size.screen_rows - 4))
     local win_config = {
       relative = "cursor",
       row = 1,


### PR DESCRIPTION
### Problem

With `only_render_image_at_cursor_mode = "popup"`, the popup window is always sized at
half the screen width, regardless of how large the image actually is. A small image — a
78x20 shields.io badge, say — gets a half-screen float with the image in one corner and a
large empty region beside it.

The aspect-ratio fit can also overshoot vertically on a tall, narrow image, pushing the
float past the bottom of the screen.

### Change

Cap the requested width at the image's natural size in cells, so the popup never asks for
more room than the image can fill:

```lua
local natural_cols = math.ceil(image.image_width / term_size.cell_width)
local requested_cols = math.min(natural_cols, math.floor(term_size.screen_cols / 2))
```

Half the screen remains the upper bound, so large images behave exactly as before — only
images narrower than that are affected.

Then clamp the fitted height to the screen:

```lua
height = math.min(height, math.max(1, term_size.screen_rows - 4))
```

### Notes

Platform-independent; not specific to any backend or terminal. Verified with badge-sized
and full-width images in a markdown buffer.
