### PR TITLE
fix: JPEG detection fails on files with trailing data (Motion Photos)

### DIFF
--- a/lua/image/utils/magic.lua
+++ b/lua/image/utils/magic.lua
@@ -24,15 +24,6 @@ local function read_file_header(file, num_bytes)
   return content and { content:byte(1, #content) } or nil
 end
 
-local function has_jpeg_end_signature(file)
-  if not file then return false end
-  local size = file:seek("end")
-  if size < 2 then return false end
-  file:seek("set", size - 2)
-  local end_signature = file:read(2)
-  return end_signature == "\xFF\xD9", nil
-end
-
 local function check_signature_match(header, format, signature)
   local bytes = { signature:byte(1, #signature) }
   local match = true
@@ -70,14 +61,8 @@ M.detect_format = function(path)
 
   for format, signature in pairs(image_signatures) do
     if check_signature_match(header, format, signature) then
-      if format == "jpeg" then
-        local is_jpeg = has_jpeg_end_signature(file)
-        file:close()
-        return is_jpeg and format or nil
-      else
-        file:close()
-        return format
-      end
+      file:close()
+      return format
     end
   end
 


### PR DESCRIPTION
detect_format() in magic.lua has a check that requires FFD9 (JPEG EOI) to
be the literal last 2 bytes of the file. That breaks on any JPEG that has
data appended after the actual image — Google/Samsung Motion Photos being
the common case (JPEG + embedded MP4 + trailer footer).

For these files the real EOI is somewhere in the middle, so
has_jpeg_end_signature() returns false and detect_format() returns nil for
the whole file, even though it's a perfectly valid JPEG. ImageMagick has
no problem with these files (tested manually with identify/convert), it
just stops reading at EOI like it's supposed to.

I don't think this check is worth keeping — no other format in the table
gets this kind of extra validation, and detect_format() has no fallback
to the identify-based path used elsewhere in the plugin, so this was a
silent permanent failure rather than just a perf hit.

Removed the EOI check and the now-unused has_jpeg_end_signature function.

Tested:
- Motion Photo JPEGs now detected/rendered correctly
- truncated JPEGs still fail sensibly downstream - partial render if
  there's enough data, clean identify error ("insufficient image data")
  if not